### PR TITLE
Pin audit-middleware to non-SNAPSHOT version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ ThisBuild / organizationName := "University of Pennsylvania"
 ThisBuild / licenses := List("Apache-2.0" -> new URL("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / startYear := Some(2021)
 
-ThisBuild / version := sys.props.get("version").getOrElse("SNAPSHOT")
+ThisBuild / version := sys.props.get("version").getOrElse("bootstrap-SNAPSHOT")
 
 val publishToNexus =
   settingKey[Option[Resolver]]("Pennsieve Nexus repository resolver")


### PR DESCRIPTION

## Changes Proposed

Tag `audit-middleware` so that SBT does not keep trying to resolve the
`SNAPSHOT` version.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
