### PR TITLE
Use `tokenString` not `name`

### DIFF
--- a/core/src/main/scala/com/blackfynn/managers/TokenManager.scala
+++ b/core/src/main/scala/com/blackfynn/managers/TokenManager.scala
@@ -159,10 +159,10 @@ class SecureTokenManager(actor: User, db: Database) extends TokenManager(db) {
         PermissionError(actor.nodeId, Write, "")
       )
       _ <- cognitoClient
-        .adminCreateToken(name, cognitoClient.getTokenPoolId())
+        .adminCreateToken(tokenString, cognitoClient.getTokenPoolId())
         .toEitherT
       _ <- cognitoClient
-        .adminSetUserPassword(name, secret, cognitoClient.getTokenPoolId())
+        .adminSetUserPassword(tokenString, secret, cognitoClient.getTokenPoolId())
         .toEitherT
       tokenId <- db
         .run((TokensMapper returning TokensMapper.map(_.id)) += token)


### PR DESCRIPTION
Fixes mistake where token creation uses the user input "name" value. This easily leads to name collisions.