### PR TITLE
Refactors cognito jwt auth flow to working state

### DIFF
--- a/bf-akka-http/src/main/scala/com/blackfynn/akka/http/directives/AuthorizationDirectives.scala
+++ b/bf-akka-http/src/main/scala/com/blackfynn/akka/http/directives/AuthorizationDirectives.scala
@@ -22,17 +22,30 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.Credentials
 import cats.data.EitherT
 import cats.implicits._
-import com.blackfynn.aws.cognito.CognitoJWTAuthenticator
-import com.pennsieve.auth.middleware.{Jwt, UserClaim}
+import com.pennsieve.aws.cognito.CognitoJWTAuthenticator
+import com.pennsieve.auth.middleware.{ Jwt, UserClaim }
 import com.pennsieve.aws.cognito.CognitoConfig
-import com.pennsieve.core.utilities.{FutureEitherHelpers, JwtAuthenticator, OrganizationManagerContainer, SessionManagerContainer, TokenManagerContainer, UserAuthContext, UserManagerContainer}
-import com.pennsieve.domain.{CoreError, Error, ThrowableError}
-import com.pennsieve.domain.Sessions.{APISession, BrowserSession, Session, TemporarySession}
-import com.pennsieve.models.{Organization, User}
+import com.pennsieve.core.utilities.{
+  FutureEitherHelpers,
+  JwtAuthenticator,
+  OrganizationManagerContainer,
+  SessionManagerContainer,
+  TokenManagerContainer,
+  UserAuthContext,
+  UserManagerContainer
+}
+import com.pennsieve.domain.{ CoreError, Error, ThrowableError }
+import com.pennsieve.domain.Sessions.{
+  APISession,
+  BrowserSession,
+  Session,
+  TemporarySession
+}
+import com.pennsieve.models.{ Organization, User }
 import com.pennsieve.utilities.Container
 import net.ceedubs.ficus.Ficus._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 object AuthorizationDirectives {
 

--- a/core/src/main/scala/com/blackfynn/aws/cognito/CognitoConfig.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/CognitoConfig.scala
@@ -20,6 +20,7 @@ import com.auth0.jwk.JwkProvider
 import net.ceedubs.ficus.Ficus._
 import com.typesafe.config.Config
 import software.amazon.awssdk.regions.Region
+import java.net.URL
 
 case class CognitoConfig(
   region: Region,
@@ -29,12 +30,26 @@ case class CognitoConfig(
 
   // TODO: separate providers for each pool
   lazy val jwkProvider = CognitoJWTAuthenticator.getJwkProvider(userPool)
+
 }
 
 /**
   * Config for a single Cognito User Pool
   */
-case class CognitoPoolConfig(region: Region, id: String, appClientId: String)
+case class CognitoPoolConfig(region: Region, id: String, appClientId: String) {
+
+  def endpoint: String =
+    s"https://cognito-idp.${region.toString}.amazonaws.com/$id"
+
+  /**
+    * Must be a URL type - Auth0 JDK provider strips string endpoints down to
+    * their domain name.
+    */
+  def jwkUrl: URL =
+    new URL(
+      s"https://cognito-idp.${region.toString}.amazonaws.com/$id/.well-known/jwks.json"
+    )
+}
 
 object CognitoConfig {
 

--- a/core/src/test/scala/com/blackfynn/aws/cognito/CognitoJWTAuthenticatorSpec.scala
+++ b/core/src/test/scala/com/blackfynn/aws/cognito/CognitoJWTAuthenticatorSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.blackfynn.aws.cognito
+package com.pennsieve.aws.cognito
 
 import com.auth0.jwk.{ Jwk, JwkProvider }
 import com.pennsieve.models.CognitoId
@@ -75,12 +75,6 @@ class CognitoJWTAuthenticatorSpec extends FlatSpec with Matchers {
   //  var invalidToken: String = JwtCirce.encode
 
   var jwkProvider: JwkProvider = new MockJwkProvider(jwk)
-
-  "getKeysUrl" should "return the correct URL given arguments" in {
-    CognitoJWTAuthenticator.getKeysUrl("foo", "bar") should equal(
-      "https://cognito-idp.foo.amazonaws.com/bar/.well-known/jwks.json"
-    )
-  }
 
   "getKeyId" should "work" in {
     CognitoJWTAuthenticator.getKeyId(testToken) should equal(


### PR DESCRIPTION
## Changes Proposed
- makes necessary changes based on live testing deploy w/ Bo
- refactors `awsRegion` etc info into an implicit `CognitoConfig` object as opposed to arguments
  - sets up `jwkProvider` into `CognitoConfig` as a `lazy` var
- ensures `JwkProvider` is supplied with a `URL` object, and not a `String` for the endpoint

## Checklist

- [ ] unit tests added and/or verified that tests pass
  - will likely need to address failing tests in separate PR / further commits to get this to a deployable state
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
