### PR TITLE
Convert UserInvite to User from Cognito JWT

### DIFF
--- a/api/src/main/scala/ScalatraBootstrap.scala
+++ b/api/src/main/scala/ScalatraBootstrap.scala
@@ -72,7 +72,11 @@ class ScalatraBootstrap extends LifeCycle with LazyLogging {
       // account endpoints
       ///////////////////////////////
       val accountController =
-        new AccountController(bootstrapHelper.insecureContainer, ec)
+        new AccountController(
+          bootstrapHelper.insecureContainer,
+          bootstrapHelper.cognitoConfig,
+          ec
+        )
       context mount (accountController, "/account/*", "account")
 
       // annotation endpoints

--- a/api/src/main/scala/com/blackfynn/helpers/BootstrapHelper.scala
+++ b/api/src/main/scala/com/blackfynn/helpers/BootstrapHelper.scala
@@ -24,12 +24,11 @@ import com.amazonaws.ClientConfiguration
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
 import com.amazonaws.services.s3.S3ClientOptions
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import com.authy.AuthyApiClient
 import com.pennsieve.auth.middleware.{ Jwt, UserClaim, UserId }
-import com.pennsieve.aws.cognito.CognitoClient
+import com.pennsieve.aws.cognito.{ CognitoClient, CognitoConfig }
 import com.pennsieve.aws.s3.AWSS3Container
 import com.pennsieve.aws.s3.LocalS3Container
 import net.ceedubs.ficus.Ficus._
@@ -134,7 +133,8 @@ trait BaseBootstrapHelper {
 
   lazy val sqsClient: SQSClient = new SQS(awsSQSClient)
 
-  lazy val cognitoClient: CognitoClient = Cognito(config)
+  lazy val cognitoConfig: CognitoConfig = CognitoConfig(config)
+  lazy val cognitoClient: CognitoClient = Cognito(cognitoConfig)
 
   lazy val modelServiceClient = {
 

--- a/api/src/test/scala/com/blackfynn/api/TestAccountController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestAccountController.scala
@@ -16,10 +16,12 @@
 
 package com.pennsieve.api
 
+import com.pennsieve.aws.cognito._
 import com.pennsieve.aws.email.LoggingEmailer
 import com.pennsieve.models.DBPermission
 import com.pennsieve.web.Settings
 import com.pennsieve.aws.cognito.MockCognito
+import software.amazon.awssdk.regions.Region
 
 import java.time.Duration
 
@@ -30,11 +32,21 @@ import org.scalatest._
 
 class TestAccountController extends BaseApiTest {
 
+  val cognitoConfig = CognitoConfig(
+    Region.US_EAST_1,
+    CognitoPoolConfig(Region.US_EAST_1, "user-pool-id", "client-id"),
+    CognitoPoolConfig(Region.US_EAST_1, "token-pool-id", "client-id")
+  )
+
   override def afterStart(): Unit = {
     super.afterStart()
 
     addServlet(
-      new AccountController(insecureContainer, system.dispatcher),
+      new AccountController(
+        insecureContainer,
+        cognitoConfig,
+        system.dispatcher
+      ),
       "/*"
     )
   }

--- a/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
@@ -75,10 +75,7 @@ trait CognitoClient {
 
 object Cognito {
 
-  def apply(config: Config): Cognito = {
-
-    val cognitoConfig = CognitoConfig(config)
-
+  def apply(cognitoConfig: CognitoConfig): Cognito =
     new Cognito(
       CognitoIdentityProviderAsyncClient
         .builder()
@@ -87,12 +84,14 @@ object Cognito {
         .build(),
       cognitoConfig
     )
-  }
+
+  def apply(config: Config): Cognito =
+    Cognito(CognitoConfig(config))
 }
 
 class Cognito(
   val client: CognitoIdentityProviderAsyncClient,
-  cognitoConfig: CognitoConfig
+  val cognitoConfig: CognitoConfig
 ) extends CognitoClient {
 
   def inviteUser(

--- a/core/src/main/scala/com/blackfynn/aws/cognito/CognitoJWTAuthenticator.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/CognitoJWTAuthenticator.scala
@@ -22,6 +22,13 @@ import io.circe.{ Decoder, Encoder }
 import io.circe.parser.decode
 import pdi.jwt.{ JwtAlgorithm, JwtCirce, JwtClaim, JwtOptions }
 import cats.implicits._
+import com.pennsieve.core.utilities.checkOrError
+import com.pennsieve.domain.{
+  CoreError,
+  InvalidJWT,
+  ParseError,
+  ThrowableError
+}
 import com.pennsieve.models.CognitoId
 
 import java.time.Instant
@@ -38,18 +45,20 @@ object CognitoPayload {
     * @param resourceServer All scopes that are not related to the
     *        given resource server will be filtered out
     */
-  def apply(claim: JwtClaim): Either[Throwable, CognitoPayload] =
+  def apply(claim: JwtClaim): Either[CoreError, CognitoPayload] =
     for {
       subject <- Either.fromOption(
         claim.subject,
-        new Throwable("JWT claim missing 'sub' field")
+        InvalidJWT(claim.content, Some("JWT claim missing 'sub' field"))
       )
       cognitoId = CognitoId(UUID.fromString(subject))
       issuedAt <- Either.fromOption(
         claim.issuedAt,
-        new Throwable("JWT claim missing 'iat' field:")
+        InvalidJWT(claim.content, Some("JWT claim missing 'iat' field"))
       )
-      issuedAtInstant <- Either.catchNonFatal(Instant.ofEpochSecond(issuedAt))
+      issuedAtInstant <- Either
+        .catchNonFatal(Instant.ofEpochSecond(issuedAt))
+        .leftMap(ThrowableError(_))
     } yield CognitoPayload(cognitoId, issuedAtInstant)
 }
 
@@ -62,13 +71,16 @@ object CognitoJWTAuthenticator {
     token: String
   )(implicit
     cognitoConfig: CognitoConfig
-  ): Either[Throwable, CognitoPayload] = {
+  ): Either[CoreError, CognitoPayload] = {
     for {
       keyId <- getKeyId(token)
-      jwk <- Either.catchNonFatal(cognitoConfig.jwkProvider.get(keyId))
+      jwk <- Either
+        .catchNonFatal(cognitoConfig.jwkProvider.get(keyId))
+        .leftMap(ThrowableError(_))
       claim <- JwtCirce
         .decode(token, jwk.getPublicKey, Seq(JwtAlgorithm.RS256))
         .toEither
+        .leftMap(_ => InvalidJWT(token))
       _ <- validateClaim(claim)
       payload <- CognitoPayload(claim)
     } yield payload
@@ -78,15 +90,16 @@ object CognitoJWTAuthenticator {
    * Parse the JWT without verifying the signature here only to retrieve the
    * header's kid for use in later validation
    */
-  def getKeyId(token: String): Either[Throwable, String] = {
+  def getKeyId(token: String): Either[CoreError, String] = {
     JwtCirce
       .decodeAll(token, options = JwtOptions(signature = false))
       .toEither
+      .leftMap(_ => InvalidJWT(token))
       .flatMap {
         case (header, _, _) =>
           Either.fromOption(
             header.keyId,
-            new Exception("kid not present in JWT header")
+            InvalidJWT(token, Some("kid not present in JWT header"))
           )
       }
   }
@@ -109,20 +122,19 @@ object CognitoJWTAuthenticator {
     claim: JwtClaim
   )(implicit
     cognitoConfig: CognitoConfig
-  ): Either[Throwable, Unit] =
-    decode[CognitoContent](claim.content).flatMap { content =>
-      (
-        claim.issuer.contains(cognitoConfig.userPool.endpoint),
+  ): Either[CoreError, Unit] =
+    for {
+      content <- decode[CognitoContent](claim.content).leftMap(ParseError(_))
+
+      _ <- checkOrError(claim.issuer.contains(cognitoConfig.userPool.endpoint))(
+        InvalidJWT(claim.content, Some("claim contains invalid issuer"))
+      )
+
+      _ <- checkOrError(
         content.client_id.exists(_ == cognitoConfig.userPool.appClientId)
           || claim.audience
             .exists(_.contains(cognitoConfig.userPool.appClientId))
-      ) match {
-        case (false, _) => Left(new Exception("claim contains invalid issuer"))
-        case (_, false) => {
-          Left(new Exception("claim contains invalid audience"))
-        }
-        case _ => Right(())
-      }
-    }
+      )(InvalidJWT(claim.content, Some("claim contains invalid audience")))
 
+    } yield ()
 }

--- a/core/src/main/scala/com/blackfynn/domain/CoreError.scala
+++ b/core/src/main/scala/com/blackfynn/domain/CoreError.scala
@@ -86,8 +86,10 @@ case class Error(message: String) extends CoreError {
   final override def getMessage: String = message
 }
 
-case class InvalidJWT(token: String) extends CoreError {
-  final override def getMessage: String = s"Not a JWT: ${token}"
+case class InvalidJWT(token: String, reason: Option[String] = None)
+    extends CoreError {
+  final override def getMessage: String =
+    s"""Invalid JWT: ${reason.map(_ + ":").getOrElse("")} $token"""
 }
 
 case class UnsupportedJWTClaimType(`type`: String) extends CoreError {


### PR DESCRIPTION
## Changes Proposed

Update the `POST /account` endpoint to parse the Cognito user ID from
the Cognito JWT to convert a user invite to a full user.

Update Cognito JWT parsing code to fail with `CoreError` instead of
`Throwable`.


## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
