### PR TITLE
Set preferred organization for all users

### DIFF
--- a/core/src/main/scala/com/blackfynn/db/UserInviteTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/UserInviteTable.scala
@@ -70,7 +70,7 @@ object UserInvitesMapper extends TableQuery(new UserInvitesTable(_)) {
     this.filter(_.nodeId === nodeId).result.headOption
 
   def getByCognitoId(cognitoId: CognitoId) =
-    this.filter(_.cognitoId === cognitoId).result
+    this.filter(_.cognitoId === cognitoId).sortBy(_.createdAt.desc).result
 
   def getByEmail(email: String) =
     this.filter(_.email.toLowerCase === email.toLowerCase)

--- a/core/src/main/scala/com/blackfynn/db/UserTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/UserTable.scala
@@ -89,7 +89,7 @@ object UserMapper extends TableQuery(new UserTable(_)) {
   def getByEmail(email: String) =
     this.filter(_.email.toLowerCase === email.toLowerCase).result.headOption
 
-  def getByCognitoId(cognitoId: CognitoId) =
+  def getByCognitoId(cognitoId: CognitoId): DBIO[Option[(User, CognitoUser)]] =
     this
       .join(CognitoUserMapper)
       .on(_.id === _.userId)

--- a/core/src/main/scala/com/blackfynn/managers/UserInviteManager.scala
+++ b/core/src/main/scala/com/blackfynn/managers/UserInviteManager.scala
@@ -88,7 +88,6 @@ class UserInviteManager(db: Database) {
           // TODO: clean this up. Move Cognito IDs and emails to a separate
           // table with proper constraints.
           case None =>
-            val token = UUID.randomUUID().toString
             val nodeId = NodeCodes.generateId(NodeCodes.userCode)
             val validUntil = ZonedDateTime.now().plus(ttl)
 

--- a/core/src/main/scala/com/blackfynn/managers/UserManager.scala
+++ b/core/src/main/scala/com/blackfynn/managers/UserManager.scala
@@ -233,6 +233,8 @@ class UserManager(db: Database) {
 
       middleInit <- checkAndNormalizeInitial(middleInitial).toEitherT[Future]
 
+      // TODO: set preferred organization
+
       user: User = User(
         NodeCodes.generateId(NodeCodes.userCode),
         headInvite.email.trim.toLowerCase,
@@ -241,7 +243,8 @@ class UserManager(db: Database) {
         lastName,
         degree,
         password = "",
-        credential = title
+        credential = title,
+        preferredOrganizationId = Some(headInvite.organizationId)
       )
 
       newUser <- create(user, Some(password))

--- a/core/src/test/scala/com/blackfynn/managers/UserManagerSpec.scala
+++ b/core/src/test/scala/com/blackfynn/managers/UserManagerSpec.scala
@@ -123,6 +123,7 @@ class UserManagerSpec extends BaseManagerSpec {
       .value
 
     assert(user.email == email)
+    assert(user.preferredOrganizationId == Some(testOrganization.id))
 
     val secureOrganizationManager = organizationManager(user)
     secureOrganizationManager.get(testOrganization.id).await.value
@@ -189,6 +190,7 @@ class UserManagerSpec extends BaseManagerSpec {
       .value
 
     assert(user.email == email)
+    assert(user.preferredOrganizationId == Some(orgsInvites.last._1.id))
 
     val secureOrganizationManager =
       new SecureOrganizationManager(database, user)
@@ -207,6 +209,7 @@ class UserManagerSpec extends BaseManagerSpec {
   }
 
   // TODO: create this as part of createUser?
+
   def createCognitoUser(user: User): CognitoId =
     database
       .run(CognitoUserMapper.create(CognitoId.randomId(), user))


### PR DESCRIPTION

## Changes Proposed

Set a preferred organization for newly created users so that initial
requests do not return errors.


## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
