### PR TITLE
Fix client token creation

### DIFF
--- a/api/src/main/scala/com/blackfynn/api/AuthenticatedController.scala
+++ b/api/src/main/scala/com/blackfynn/api/AuthenticatedController.scala
@@ -335,10 +335,10 @@ trait AuthenticatedController
       Option(request.getHeader(AuditLogger.TRACE_ID_HEADER)).map(TraceId(_))
     )
 
-  def getSessionId(request: HttpServletRequest): Option[String] = {
+  def getCognitoId(request: HttpServletRequest): Option[CognitoId] = {
     getJwtClaim(request).toOption.flatMap { claim =>
       claim.content match {
-        case UserClaim(_, _, session, _) => session.map(_.id)
+        case UserClaim(_, _, cognito, _) => cognito.map(_.id)
         case _ => None
       }
     }
@@ -347,7 +347,7 @@ trait AuthenticatedController
   def isBrowserSession(request: HttpServletRequest): Boolean = {
     getJwtClaim(request).exists { claim =>
       claim.content match {
-        case UserClaim(_, _, Some(session), _) => session.isBrowser
+        case UserClaim(_, _, Some(cognito), _) => cognito.isBrowser
         case _ => false
       }
     }

--- a/api/src/test/scala/com/blackfynn/api/BaseApiTest.scala
+++ b/api/src/test/scala/com/blackfynn/api/BaseApiTest.scala
@@ -26,6 +26,7 @@ import com.pennsieve.aws.email.LocalEmailContainer
 import com.pennsieve.aws.queue.LocalSQSContainer
 import com.pennsieve.aws.s3.LocalS3Container
 import com.pennsieve.models.{
+  CognitoId,
   Dataset,
   DatasetStatus,
   Degree,
@@ -459,7 +460,7 @@ trait ApiSuite
     apiJwt = Authenticator.createUserToken(
       loggedInUser,
       loggedInOrganization,
-      session = Session.API(UUID.randomUUID.toString)
+      cognito = CognitoSession.API(CognitoId.TokenPoolId.randomId)
     )(jwtConfig, insecureContainer.db, ec)
 
     secureContainer.datasetStatusManager.resetDefaultStatusOptions.await.right.value
@@ -549,7 +550,7 @@ trait ApiSuite
     datasetRole: Role = Role.Owner,
     expiration: FiniteDuration = 10.seconds,
     userId: Int = loggedInUser.id,
-    session: Option[Session] = None
+    cognito: Option[CognitoSession] = None
   ): Map[String, String] = {
     val jwtClaim = Jwt.generateClaim(
       UserClaim(
@@ -566,7 +567,7 @@ trait ApiSuite
             role = datasetRole
           )
         ),
-        session = session
+        cognito = cognito
       ),
       expiration
     )

--- a/api/src/test/scala/com/blackfynn/api/TestUsersController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestUsersController.scala
@@ -226,43 +226,6 @@ class TestUsersController extends BaseApiTest {
     }
   }
 
-  test(
-    "switch rejects request when user is not a member of the specified organization"
-  ) {
-    putJson(
-      s"/organization/${externalOrganization.nodeId}/switch",
-      "",
-      headers = authorizationHeader(loggedInJwt)
-    ) {
-      response.status shouldBe 404
-    }
-  }
-
-  test(
-    "switch correctly redirects request when user is a member of the specified organization"
-  ) {
-    organizationManager
-      .addUser(externalOrganization, loggedInUser, Delete)
-      .await
-
-    val sessionId: String =
-      Jwt.parseClaim(Jwt.Token(loggedInJwt))(jwtConfig).map(_.content) match {
-        case Right(UserClaim(_, _, Some(session), _)) => session.id
-        case _ =>
-          throw new Exception(
-            "invalid JWT in test must be UserClaim with Session."
-          )
-      }
-
-    putJson(
-      s"/organization/${externalOrganization.nodeId}/switch",
-      headers = authorizationHeader(loggedInJwt)
-    ) {
-      response.status shouldBe 301
-      response.getHeader("Location") shouldBe s"http://localhost/session/switch-organization?organization_id=${externalOrganization.id}&api_key=$sessionId"
-    }
-  }
-
   test("two factor creation") {
     val twoFactorReq = write(AddAuthyRequest(Some("111-111-1111"), Some("1")))
 

--- a/api/src/test/scala/com/blackfynn/helpers/Authenticator.scala
+++ b/api/src/test/scala/com/blackfynn/helpers/Authenticator.scala
@@ -18,6 +18,7 @@ package com.pennsieve.helpers
 
 import cats.implicits._
 import com.pennsieve.auth.middleware.{
+  CognitoSession,
   DatasetId,
   DatasetNodeId,
   EncryptionKeyId,
@@ -25,7 +26,6 @@ import com.pennsieve.auth.middleware.{
   OrganizationId,
   OrganizationNodeId,
   ServiceClaim,
-  Session,
   UserClaim,
   UserId
 }
@@ -39,6 +39,7 @@ import com.pennsieve.db.{
   UserMapper
 }
 import com.pennsieve.models.{
+  CognitoId,
   DBPermission,
   Dataset,
   Feature,
@@ -64,7 +65,8 @@ object Authenticator {
     user: User,
     organization: Organization,
     datasetId: Option[Int] = None,
-    session: Session = Session.Browser(UUID.randomUUID.toString),
+    cognito: CognitoSession =
+      CognitoSession.Browser(CognitoId.UserPoolId.randomId),
     duration: FiniteDuration = 60.seconds
   )(implicit
     config: Jwt.Config,
@@ -80,7 +82,7 @@ object Authenticator {
       val roles =
         List(organizationRole.some, datasetRole).flatten
       val userClaim =
-        UserClaim(id = UserId(user.id), roles = roles, session = Some(session))
+        UserClaim(id = UserId(user.id), roles = roles, cognito = Some(cognito))
       val claim =
         Jwt.generateClaim(userClaim, duration)
 

--- a/authorization-service/src/main/scala/com/blackfynn/authorization/Router.scala
+++ b/authorization-service/src/main/scala/com/blackfynn/authorization/Router.scala
@@ -72,7 +72,7 @@ class Router(
         val authorization = new AuthorizationRoutes(
           user = userContext.user,
           organization = userContext.organization,
-          session = userContext.session
+          cognitoId = userContext.cognitoId
         )(container, executionContext, system)
 
         logByEnvironment(authorization.routes)

--- a/authorization-service/src/main/scala/com/blackfynn/authorization/routes/AuthorizationRoutes.scala
+++ b/authorization-service/src/main/scala/com/blackfynn/authorization/routes/AuthorizationRoutes.scala
@@ -34,6 +34,7 @@ import slick.sql.FixedSqlStreamingAction
 import cats.implicits._
 import com.pennsieve.akka.http.RouteService
 import com.pennsieve.auth.middleware.{
+  CognitoSession,
   DatasetId,
   DatasetNodeId,
   EncryptionKeyId,
@@ -43,8 +44,7 @@ import com.pennsieve.auth.middleware.{
   UserClaim,
   UserId,
   UserNodeId,
-  WorkspaceId,
-  Session => JwtSession
+  WorkspaceId
 }
 import com.pennsieve.authorization.Router.ResourceContainer
 import com.pennsieve.authorization.utilities.exceptions._
@@ -64,7 +64,7 @@ import scala.util.{ Failure, Success, Try }
 class AuthorizationRoutes(
   user: User,
   organization: Organization,
-  session: Option[String]
+  cognitoId: Option[CognitoId]
 )(implicit
   container: ResourceContainer,
   executionContext: ExecutionContext,
@@ -121,7 +121,7 @@ class AuthorizationRoutes(
       } yield {
         val roles =
           List(organizationRole.some, datasetRole, workspaceRole).flatten
-        val userClaim = getUserClaim(user, roles)
+        val userClaim = getUserClaim(user, roles, cognitoId)
         val claim =
           Jwt.generateClaim(userClaim, container.duration)
 
@@ -154,19 +154,13 @@ class AuthorizationRoutes(
     (path("switch-organization") & parameters('organization_id.as[Int]) & put) {
       (organizationId) =>
         val result: Future[UserDTO] = for {
-          // TODO: Only allow users to change sessions, not client tokens
-//          _ <- session.isBrowserSession match {
-//            case true => Future.successful(())
-//            case false => Future.failed(NonBrowserSession)
-//          }
+
+          // Only users logged in from the browser / user pool can switch organizations
+          _ <- cognitoId.map(_.asUserPoolId) match {
+            case Some(Right(_)) => Future.successful(())
+            case _ => Future.failed(NonBrowserSession)
+          }
           organizationToSwitchTo <- getOrganization(user, organizationId)
-//          savedSession <- Future.fromTry(
-//            container.sessionManager
-//              .update(
-//                session.copy(organizationId = organizationToSwitchTo.nodeId)
-//              )
-//              .toTry
-//          )
           updatedUser <- updateUserPreferredOrganization(
             user,
             organizationToSwitchTo
@@ -195,20 +189,18 @@ class AuthorizationRoutes(
 
   private def getUserClaim(
     user: User,
-    roles: List[Jwt.Role]
-//    session: Session
+    roles: List[Jwt.Role],
+    cognitoId: Option[CognitoId]
   ): UserClaim = {
-//    val jwtSession: JwtSession = session.`type` match {
-//      case Sessions.APISession(_) => JwtSession.API(session.uuid)
-//      case Sessions.BrowserSession => JwtSession.Browser(session.uuid)
-//      case Sessions.TemporarySession => JwtSession.Temporary(session.uuid)
-//    }
+    val cognitoSession = cognitoId.map {
+      case id: CognitoId.TokenPoolId => CognitoSession.API(id)
+      case id: CognitoId.UserPoolId => CognitoSession.Browser(id)
+    }
 
     UserClaim(
       id = UserId(user.id),
       roles = roles,
-//      session = Some(jwtSession),
-      session = None,
+      cognito = cognitoSession,
       node_id = Some(UserNodeId(user.nodeId))
     )
   }

--- a/bf-akka-http/src/main/scala/com/blackfynn/akka/http/directives/AuthorizationDirectives.scala
+++ b/bf-akka-http/src/main/scala/com/blackfynn/akka/http/directives/AuthorizationDirectives.scala
@@ -101,7 +101,7 @@ object AuthorizationDirectives {
         UserAuthContext(
           user = user,
           organization = organization,
-          session = Some(session.uuid)
+          cognitoId = None
         )
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val akkaHttpVersion = "10.1.11"
 lazy val akkaStreamContribVersion = "0.11"
 lazy val alpakkaVersion = "2.0.2"
 lazy val auditMiddlewareVersion = "1.0.1"
-lazy val authMiddlewareVersion = "4.2.3"
+lazy val authMiddlewareVersion = "5.0.1"
 
 lazy val authyVersion = "1.5.1"
 lazy val awsVersion = "1.11.931"

--- a/core/src/main/scala/com/blackfynn/db/TokenTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/TokenTable.scala
@@ -21,6 +21,7 @@ import java.time.ZonedDateTime
 import com.pennsieve.models.{ CognitoId, Token }
 import com.pennsieve.traits.PostgresProfile.api._
 
+// TODO: unique cognito_id
 final class TokenTable(tag: Tag)
     extends Table[Token](tag, Some("pennsieve"), "tokens") {
 


### PR DESCRIPTION
## Changes Proposed

Only "browser" sessions are allowed to create API client tokens. Because
we are now using Cognito JWTs this flow was breaking. This PR pulls in
the changes from https://github.com/Pennsieve/auth-middleware/pull/2 to
store the Cognito ID in the internal JWT so that the token endpoints
work.

In addition this PR removes the `/organization/:id/switch` endpoint redirect
in favor of calling `/session/switch-organization` directly. 

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
