### PR TITLE
Add missing CognitoId to auth context

### DIFF
--- a/bf-akka-http/src/main/scala/com/blackfynn/akka/http/directives/AuthorizationDirectives.scala
+++ b/bf-akka-http/src/main/scala/com/blackfynn/akka/http/directives/AuthorizationDirectives.scala
@@ -215,7 +215,7 @@ object AuthorizationDirectives {
             organization <- container.organizationManager.get(
               preferredOrganizationId
             )
-          } yield UserAuthContext(user._1, organization, None)
+          } yield UserAuthContext(user._1, organization, Some(cognitoId))
 
         case id: CognitoId.TokenPoolId =>
           for {
@@ -225,7 +225,7 @@ object AuthorizationDirectives {
             organization <- container.organizationManager.get(
               token.organizationId
             )
-          } yield UserAuthContext(user, organization, None)
+          } yield UserAuthContext(user, organization, Some(cognitoId))
 
       }
     } yield authContext


### PR DESCRIPTION
## Changes Proposed

Add the extracted CognitoId to the auth context when parsing the JWT.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
