### PR TITLE
Auto-verify email addresses on Cognito creation

### DIFF
--- a/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
@@ -94,6 +94,11 @@ class Cognito(
   val cognitoConfig: CognitoConfig
 ) extends CognitoClient {
 
+  /**
+    * Verify user email addresses on Cognito account creation. Users only need
+    * to use the verification flow if they sign themselves up, which we don't
+    * support yet.
+    */
   def inviteUser(
     email: Email
   )(implicit
@@ -103,6 +108,12 @@ class Cognito(
       .builder()
       .userPoolId(cognitoConfig.userPool.id)
       .username(email.address)
+      .userAttributes(
+        List(
+          AttributeType.builder().name("email").value(email.address).build(),
+          AttributeType.builder().name("email_verified").value("True").build()
+        ).asJava
+      )
       .desiredDeliveryMediums(List(DeliveryMediumType.EMAIL).asJava)
       .build()
     adminCreateUser(request).map(CognitoId.UserPoolId(_))

--- a/core/src/main/scala/com/blackfynn/aws/cognito/CognitoJWTAuthenticator.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/CognitoJWTAuthenticator.scala
@@ -112,6 +112,10 @@ object CognitoJWTAuthenticator {
   private case class TokenPool(pool: CognitoPoolConfig) extends Issuer
   private case class UserPool(pool: CognitoPoolConfig) extends Issuer
 
+  /**
+    * Cognito adds a `client_id` to the JWT which is not part of the JWT
+    * standard.  This case class is needed to parse the id.
+    */
   case class CognitoContent(client_id: Option[String])
 
   object CognitoContent {


### PR DESCRIPTION

## Changes Proposed

Verify user email addresses on Cognito account creation. Users only need
to use the verification flow if they sign themselves up, which we don't
support.

Ref: https://app.clickup.com/t/qx791c


## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
