### PR TITLE
removing username from forgot password emails

### DIFF
--- a/message-templates/mjml/password-reset.mjml
+++ b/message-templates/mjml/password-reset.mjml
@@ -65,11 +65,11 @@
       <mj-column padding="16px 0">
         <mj-text height="40px">
           <!--[if mso]>
-            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://app.${PENNSIEVE_DOMAIN}/?verificationCode={####}&email={username}" style="height:40px;v-text-anchor:middle;width:148px;" arcsize="8%" stroke="f" fillcolor="#5039F7">
+            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://app.${PENNSIEVE_DOMAIN}/?verificationCode={####}" style="height:40px;v-text-anchor:middle;width:148px;" arcsize="8%" stroke="f" fillcolor="#5039F7">
               <w:anchorlock/>
               <center>
             <![endif]-->
-                <a href="https://app.${PENNSIEVE_DOMAIN}/password?verificationCode={####}&email={username}"
+                <a href="https://app.${PENNSIEVE_DOMAIN}/password?verificationCode={####}"
           style="background-color:#5039F7;border-radius:3px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:14px;font-weight:500;line-height:40px;text-align:center;text-decoration:none;width:148px;-webkit-text-size-adjust:none;">Password Reset</a>
             <!--[if mso]>
               </center>


### PR DESCRIPTION
## Changes Proposed
1. removing username from forgot password emails, aws doesn't supply this in the link

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
