### PR TITLE
Fix token user attributes

### DIFF
--- a/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
@@ -33,8 +33,6 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.{
   AdminDeleteUserRequest,
   AdminDeleteUserResponse,
   AdminSetUserPasswordRequest,
-  AdminUpdateUserAttributesRequest,
-  AdminUpdateUserAttributesResponse,
   AttributeType,
   DeliveryMediumType,
   MessageActionType,
@@ -138,20 +136,6 @@ class Cognito(
       .builder()
       .userPoolId(cognitoConfig.tokenPool.id)
       .username(token)
-      .build()
-
-    val setPasswordRequest = AdminSetUserPasswordRequest
-      .builder()
-      .password(secret.plaintext)
-      .permanent(true)
-      .userPoolId(cognitoConfig.tokenPool.id)
-      .username(token)
-      .build()
-
-    val updateUserAttributesRequest = AdminUpdateUserAttributesRequest
-      .builder()
-      .username(token)
-      .userPoolId(cognitoConfig.tokenPool.id)
       .userAttributes(
         List(
           AttributeType
@@ -168,15 +152,19 @@ class Cognito(
       )
       .build()
 
+    val setPasswordRequest = AdminSetUserPasswordRequest
+      .builder()
+      .password(secret.plaintext)
+      .permanent(true)
+      .userPoolId(cognitoConfig.tokenPool.id)
+      .username(token)
+      .build()
+
     for {
       cognitoId <- adminCreateUser(createUserRequest)
 
       _ <- client
         .adminSetUserPassword(setPasswordRequest)
-        .toScala
-
-      _ <- client
-        .adminUpdateUserAttributes(updateUserAttributesRequest)
         .toScala
 
     } yield CognitoId.TokenPoolId(cognitoId)


### PR DESCRIPTION

## Changes Proposed

Set the user attributes on the token pool instead of with a separate
`adminUpdateUserAttributes` call. This fixes an IAM issue - API does not
have permission to make this call. Better to merge the calls then add an
extra IAM permission.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
