### PR TITLE
adds temporary password to cognito invite

### DIFF
--- a/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/blackfynn/aws/cognito/Cognito.scala
@@ -47,7 +47,6 @@ import scala.collection.mutable
 import net.ceedubs.ficus.Ficus._
 import com.typesafe.config.Config
 
-import scala.util.Random
 
 trait CognitoClient {
   def inviteUser(
@@ -118,7 +117,7 @@ class Cognito(
       .builder()
       .userPoolId(cognitoConfig.userPool.id)
       .username(email.address)
-      .temporaryPassword(Random.alphanumeric.take(6).mkString(""))
+      .temporaryPassword(UUID.randomUUID().toString())
       .userAttributes(
         List(
           AttributeType.builder().name("email").value(email.address).build(),


### PR DESCRIPTION
## Changes Proposed
1. Adds a 6 character randomized alphanumeric string as a temporary password; allows us to sidestep the inclusion of any special characters that would confuse the client's router or any other URI mishaps from Cognito produced temporary passwords

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
