### PR TITLE
Drop cognito_users table

### DIFF
--- a/core/src/test/scala/com/blackfynn/test/PostgresDockerContainer.scala
+++ b/core/src/test/scala/com/blackfynn/test/PostgresDockerContainer.scala
@@ -24,7 +24,7 @@ import java.time.Duration
 
 final class PostgresDockerContainerImpl
     extends PostgresContainerImpl(
-      dockerImage = "pennsieve/pennsievedb:V20210418164838"
+      dockerImage = "pennsieve/pennsievedb:V20210419164838"
     )
 
 trait PostgresDockerContainer extends StackedDockerContainer {
@@ -35,7 +35,7 @@ trait PostgresDockerContainer extends StackedDockerContainer {
 
 final class PostgresSeedDockerContainerImpl
     extends PostgresContainerImpl(
-      dockerImage = "pennsieve/pennsievedb:V20210418164838-seed"
+      dockerImage = "pennsieve/pennsievedb:V20210419164838-seed"
     )
 
 trait PostgresSeedDockerContainer extends StackedDockerContainer {

--- a/core/src/test/scala/com/blackfynn/test/helpers/TestDatabase.scala
+++ b/core/src/test/scala/com/blackfynn/test/helpers/TestDatabase.scala
@@ -80,7 +80,6 @@ trait TestDatabase extends AwaitableImplicits {
   // Used to clear the tables in the test postgres database
   def clearDB: DBIO[Unit] = DBIO.seq(
     // clears organizations, subscriptions, and feature flags due to their foreign key relationships
-    sqlu"""TRUNCATE TABLE "pennsieve"."cognito_users" RESTART IDENTITY CASCADE""",
     sqlu"""TRUNCATE TABLE "pennsieve"."users" RESTART IDENTITY CASCADE""",
     sqlu"""TRUNCATE TABLE "pennsieve"."organizations" RESTART IDENTITY CASCADE""",
     sqlu"""TRUNCATE TABLE "pennsieve"."teams" RESTART IDENTITY CASCADE""",

--- a/migrations/src/main/resources/db/migrations/V20210419164838__drop_cognito_users.sql
+++ b/migrations/src/main/resources/db/migrations/V20210419164838__drop_cognito_users.sql
@@ -1,0 +1,1 @@
+DROP TABLE cognito_users;


### PR DESCRIPTION
## Changes Proposed

Drop `cognito_users` table. PR #76 has been deployed and the migration run. Everything works as expected so it is safe to drop the old table.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
