### PR TITLE
Increase timeout on model-service deletion

### DIFF
--- a/core/src/main/scala/com/blackfynn/clients/ModelServiceClient.scala
+++ b/core/src/main/scala/com/blackfynn/clients/ModelServiceClient.scala
@@ -168,6 +168,6 @@ class ModelServiceClient(client: HttpClient, host: String, port: Int)
   ): Either[CoreError, DatasetDeletionSummary] =
     delete[B, DatasetDeletionSummary](
       token,
-      s"$host:$port/internal/organizations/$organizationId/datasets/$datasetId?batchSize=1000&duration=2000"
+      s"$host:$port/internal/organizations/$organizationId/datasets/$datasetId?batchSize=1000&duration=5000"
     )
 }


### PR DESCRIPTION

## Changes Proposed

I am trying to delete PPMI and other Blackfynn datasets using the delete
job. However `model-service` is getting stuck with the 2 second ceiling
on the call, let's see what happens with a 5 second timeout.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
