### PR TITLE
adds controller level block on demo org for data set publishing

### DIFF
--- a/api/src/main/scala/com/blackfynn/api/DataSetsController.scala
+++ b/api/src/main/scala/com/blackfynn/api/DataSetsController.scala
@@ -2746,6 +2746,8 @@ class DataSetsController(
               case _ => None
             }
 
+          _ <- assertNotDemoOrganization(secureContainer)
+
           validated <- DataSetPublishingHelper
             .validatePublicationStatusRequest(
               secureContainer,

--- a/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
@@ -1551,6 +1551,8 @@ class OrganizationsController(
             .getByNodeId(organizationId, DBPermission.Administer)
             .coreErrorToActionResult
 
+          _ <- assertNotDemoOrganization(secureContainer)
+
           agreement <- secureContainer.dataUseAgreementManager
             .create(
               name = body.name,

--- a/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
@@ -1402,6 +1402,8 @@ class OrganizationsController(
       val result: EitherT[Future, ActionResult, DatasetStatusDTO] = for {
         secureContainer <- getSecureContainer
 
+        _ <- assertNotDemoOrganization(secureContainer)
+
         organizationId <- paramT[String]("organizationId")
         body <- extractOrErrorT[DatasetStatusRequest](parsedBody)
 

--- a/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
@@ -1596,6 +1596,8 @@ class OrganizationsController(
             .getByNodeId(organizationId, DBPermission.Administer)
             .coreErrorToActionResult
 
+          _ <- assertNotDemoOrganization(secureContainer)
+
           _ <- secureContainer.dataUseAgreementManager
             .update(
               agreementId,

--- a/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
@@ -166,6 +166,19 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
     }
   }
 
+  test("demo user should not be able to update the demo organization") {
+    val createReq =
+      write(UpdateOrganization(name = Some("Boom"), subscription = None))
+
+    putJson(
+      s"/${sandboxOrganization.nodeId}",
+      createReq,
+      headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
+    ) {
+      status should equal(403)
+    }
+  }
+
   test("update an organizations subscription requires Owner permission") {
     val updateReq = write(
       UpdateOrganization(

--- a/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
@@ -920,6 +920,21 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
     )
   }
 
+  test(
+    "demo users should not be able to create dataset options for the demo organization"
+  ) {
+    val createRequest =
+      write(DatasetStatusRequest("Ready for Publication", "#71747C"))
+
+    postJson(
+      s"/${sandboxOrganization.nodeId}/dataset-status",
+      createRequest,
+      headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
+    ) {
+      status should equal(403)
+    }
+  }
+
   test("validate dataset status options color") {
 
     val request =

--- a/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
@@ -1227,6 +1227,23 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
     }
   }
 
+  test("demo user cannot create data use agreements for organization") {
+
+    postJson(
+      s"/${sandboxOrganization.nodeId}/data-use-agreements",
+      write(
+        CreateDataUseAgreementRequest(
+          name = "New data use agreement",
+          body = "Lots of legal text",
+          description = Some("Description")
+        )
+      ),
+      headers = authorizationHeader(sandboxUserJwt)
+    ) {
+      status should equal(403)
+    }
+  }
+
   test("get data use agreements") {
 
     val agreement1 = secureContainer.dataUseAgreementManager

--- a/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
@@ -1328,6 +1328,28 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
     }
   }
 
+  test("demo user cannot update data use agreement") {
+
+    val agreement = sandboxUserContainer.dataUseAgreementManager
+      .create("New data use agreement", "Lots of legal text")
+      .await
+      .right
+      .value
+
+    putJson(
+      s"/${sandboxOrganization.nodeId}/data-use-agreements/${agreement.id}",
+      write(
+        UpdateDataUseAgreementRequest(
+          name = Some("New name"),
+          description = Some("Description")
+        )
+      ),
+      headers = authorizationHeader(sandboxUserJwt)
+    ) {
+      status should equal(403)
+    }
+  }
+
   test("fail to update non-existent data use agreement") {
 
     putJson(


### PR DESCRIPTION
## Changes Proposed
1. Blocks controller level publish data set feature if you're in a demo org
2. Blocks organization name modifications for demo organization users (Settings page)
3. Blocks dataset status and legal agreement modification for demo organization users (Settings page)

## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
