### PR TITLE
Add Windows Compatibility to Repo

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -5,6 +5,7 @@ version = 1.6.0-RC4
 align = none
 continuationIndent.defnSite = 2
 maxColumn = 80
+lineEndings = preserve
 spaces {
   inImportCurlyBraces = true
 }

--- a/uploads-consumer/src/test/resources/inputs/hello!! weird=filename.txt
+++ b/uploads-consumer/src/test/resources/inputs/hello!! weird=filename.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/uploads-consumer/src/test/resources/inputs/hello!! weird=filename?.txt
+++ b/uploads-consumer/src/test/resources/inputs/hello!! weird=filename?.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/uploads-consumer/src/test/scala/com/blackfynn/uploads/consumer/UploadHandlerSpec.scala
+++ b/uploads-consumer/src/test/scala/com/blackfynn/uploads/consumer/UploadHandlerSpec.scala
@@ -581,7 +581,7 @@ class UploadHandlerSpec extends UploadsConsumerDatabaseSpecHarness {
     }
 
     "process a clean file with special characters in the filename and pass the correct filename to the upload service" in {
-      val fileName = "hello!! weird=filename?.txt"
+      val fileName = "hello!! weird=filename.txt"
       val jobId = createJobId
       val `package`: Package = createPackage(dataset, `type` = PackageType.Text)
 
@@ -598,7 +598,6 @@ class UploadHandlerSpec extends UploadsConsumerDatabaseSpecHarness {
               .getPath
               .replace("%20", " ")
               .replace("%3d", "=")
-              .replace("%3f", "?")
           )
         )
       )
@@ -613,7 +612,7 @@ class UploadHandlerSpec extends UploadsConsumerDatabaseSpecHarness {
       runHandler(jobId, payload).value should equal(Clean)
 
       getFiles(`package`).map(_.name) should equal(
-        Vector("hello!! weird%3Dfilename%3F")
+        Vector("hello!! weird%3Dfilename")
       )
     }
 


### PR DESCRIPTION
## Changes Proposed
Two issues cause this repo to be incompatible with Windows machines when pulled:
1. Filename with a '?' in it.
2. Line ending conversion by scala format when running `sbt compile`.

The fixes to these issues:
1. Remove the '?' from the test file and update the test to reflect that.
2. Add `lineEndings = preserve` to force scala format to skip any line ending conversions. Git will automatically handle LF <-> CRLF conversions on its own when locally pulling on different operating systems.

This PR should successfully mitigate any future issues when locally using the repo on a Windows machine.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
