### PR TITLE
Demo Organization Blocks

### DIFF
--- a/api/src/main/scala/com/blackfynn/api/DataSetsController.scala
+++ b/api/src/main/scala/com/blackfynn/api/DataSetsController.scala
@@ -1552,6 +1552,9 @@ class DataSetsController(
         contributorId <- extractOrErrorT[AddContributorRequest](parsedBody)
 
         secureContainer <- getSecureContainer
+
+        _ <- assertNotDemoOrganization(secureContainer)
+
         dataset <- secureContainer.datasetManager
           .getByNodeId(datasetId)
           .orNotFound
@@ -1875,6 +1878,8 @@ class DataSetsController(
             Set(DatasetPermission.AddPeople, DatasetPermission.ChangeRoles)
           )(dataset)
           .coreErrorToActionResult
+
+        _ <- assertNotDemoOrganization(secureContainer)
 
         user <- secureContainer.userManager
           .getByNodeId(userDto.id)
@@ -2297,6 +2302,8 @@ class DataSetsController(
         body <- extractOrErrorT[SwitchOwnerRequest](parsedBody)
 
         secureContainer <- getSecureContainer
+
+        _ <- assertNotDemoOrganization(secureContainer)
 
         newOwner <- secureContainer.userManager
           .getByNodeId(body.id)

--- a/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
@@ -2157,7 +2157,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
   test("demo organization user cannot add a user as a collaborator") {
     val ds = createDataSet("Foo", container = sandboxUserContainer)
 
-    val request = write(List(loggedInUser.nodeId, Role.Editor))
+    val request = write(CollaboratorRoleDTO(loggedInUser.nodeId, Role.Editor))
     putJson(
       s"/${ds.nodeId}/collaborators/users",
       request,

--- a/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
@@ -2170,7 +2170,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       s"/${ds.nodeId}/collaborators",
       headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
     ) {
-      parsedBody.extract[List[UserDTO]].length should equal(0)
+      parsedBody.extract[CollaboratorsDTO].users.length should equal(0)
     }
   }
 

--- a/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
@@ -2157,10 +2157,10 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
   test("demo organization user cannot add a user as a collaborator") {
     val ds = createDataSet("Foo", container = sandboxUserContainer)
 
-    val ids = write(List(loggedInUser.nodeId))
+    val request = write(List(loggedInUser.nodeId, Role.Editor))
     putJson(
       s"/${ds.nodeId}/collaborators/users",
-      ids,
+      request,
       headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
     ) {
       status should equal(403)
@@ -2748,7 +2748,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       val contributors = parsedBody.extract[List[ContributorDTO]]
 
       contributors.length should equal(1)
-      contributors.map(_.id) shouldBe List(sandboxUser.id)
+      contributors.map(_.id) shouldBe List(1)
     }
   }
 


### PR DESCRIPTION
## Changes Proposed
Restricted the following functionalities from demo org users:
- Adding a user as a collaborator to a dataset
- Adding a user as a contributor to a dataset
- Switching the owner of a dataset

This is related to the changes made in #83 and should encompass all necessary restrictions for demo org users.

## Ticket
[und4yk](https://app.clickup.com/t/und4yk)


## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
