### PR TITLE
Get Users Blocks on Demo Org

### DIFF
--- a/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/blackfynn/api/OrganizationsController.scala
@@ -820,6 +820,9 @@ class OrganizationsController(
         secureContainer <- getSecureContainer
         traceId <- getTraceId(request)
         organizationId <- paramT[String]("id")
+
+        _ <- assertNotDemoOrganization(secureContainer)
+
         organization <- secureContainer.organizationManager
           .getByNodeId(organizationId)
           .coreErrorToActionResult
@@ -1142,6 +1145,8 @@ class OrganizationsController(
         traceId <- getTraceId(request)
         organizationId <- paramT[String]("organizationId")
         teamId <- paramT[String]("id")
+
+        _ <- assertNotDemoOrganization(secureContainer)
 
         organization <- secureContainer.organizationManager
           .getByNodeId(organizationId)

--- a/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestDataSetsController.scala
@@ -2165,7 +2165,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
     ) {
       status should equal(403)
     }
-    
+
     get(
       s"/${ds.nodeId}/collaborators",
       headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
@@ -3016,9 +3016,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
 
   }
 
-  test(
-    "demo organization user cannot switch owner of a dataset"
-  ) {
+  test("demo organization user cannot switch owner of a dataset") {
     val myDS = createDataSet("My DataSet", container = sandboxUserContainer)
 
     val request = write(SwitchOwnerRequest(loggedInUser.nodeId))
@@ -3037,9 +3035,8 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
     ) {
       parsedBody.extract[DataSetDTO].owner shouldBe sandboxUser.nodeId
     }
-    
-  }
 
+  }
 
   // UNSHARE
 

--- a/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/blackfynn/api/TestOrganizationsController.scala
@@ -418,6 +418,15 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
     }
   }
 
+  test("demo organization user cannot get organization members") {
+    get(
+      s"/${sandboxOrganization.nodeId}/members",
+      headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
+    ) {
+      status should equal(403)
+    }
+  }
+
   test("add an organization member") {
     // not existing user
     val email = "another@test.com"
@@ -576,6 +585,17 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
     ) {
       status should equal(200)
       assert(teamManager.getUsers(team).await.right.value.size == 0)
+    }
+  }
+
+  test("demo organization user cannot get users from a team") {
+    val team = teamManager.create("Foo", sandboxOrganization).await.right.value
+
+    get(
+      s"/${sandboxOrganization.nodeId}/teams/${team.nodeId}/members",
+      headers = authorizationHeader(sandboxUserJwt) ++ traceIdHeader()
+    ) {
+      status should equal(403)
     }
   }
 


### PR DESCRIPTION
## Changes Proposed
Demo organization users should not be able to get lists of users in the sandbox org. This PR adds the same blocks from #87 and #83 to:
- Get users in team
- Get users in org


## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
