### PR TITLE
Integration Service Models & Tables

### DIFF
--- a/core-models/src/main/scala/com/blackfynn/models/DatasetIntegration.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/DatasetIntegration.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import java.time.ZonedDateTime
+import io.circe.java8.time._
+
+final case class DatasetIntegration(
+  webhookId: Int,
+  datasetId: Int,
+  enabledBy: Int,
+  enabledOn: ZonedDateTime = ZonedDateTime.now()
+  id: Int = 0
+)
+
+object DatasetIntegration {
+  implicit val decoder: Decoder[DatasetIntegration] = deriveDecoder[DatasetIntegration]
+  implicit val encoder: Encoder[DatasetIntegration] = deriveEncoder[DatasetIntegration]
+
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled = (this.apply _).tupled
+}

--- a/core-models/src/main/scala/com/blackfynn/models/DatasetIntegration.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/DatasetIntegration.scala
@@ -25,13 +25,15 @@ final case class DatasetIntegration(
   webhookId: Int,
   datasetId: Int,
   enabledBy: Int,
-  enabledOn: ZonedDateTime = ZonedDateTime.now()
+  enabledOn: ZonedDateTime = ZonedDateTime.now(),
   id: Int = 0
 )
 
 object DatasetIntegration {
-  implicit val decoder: Decoder[DatasetIntegration] = deriveDecoder[DatasetIntegration]
-  implicit val encoder: Encoder[DatasetIntegration] = deriveEncoder[DatasetIntegration]
+  implicit val decoder: Decoder[DatasetIntegration] =
+    deriveDecoder[DatasetIntegration]
+  implicit val encoder: Encoder[DatasetIntegration] =
+    deriveEncoder[DatasetIntegration]
 
   /*
    * This is required by slick when using a companion object on a case

--- a/core-models/src/main/scala/com/blackfynn/models/Webhook.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/Webhook.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import java.time.ZonedDateTime
+import io.circe.java8.time._
+
+final case class Webhook(
+  apiUrl: String,
+  imageUrl: Option[String],
+  description: String,
+  secret: String,
+  name: String,
+  displayName: String,
+  isPrivate: Boolean,
+  isDefault: Boolean,
+  isDisabled: Boolean,
+  createdBy: Option[Int],
+  createdAt: ZonedDateTime = ZonedDateTime.now()
+  id: Int = 0
+)
+
+object Webhook {
+  implicit val decoder: Decoder[Webhook] = deriveDecoder[Webhook]
+  implicit val encoder: Encoder[Webhook] = deriveEncoder[Webhook]
+
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled = (this.apply _).tupled
+}

--- a/core-models/src/main/scala/com/blackfynn/models/Webhook.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/Webhook.scala
@@ -32,7 +32,7 @@ final case class Webhook(
   isDefault: Boolean,
   isDisabled: Boolean,
   createdBy: Option[Int],
-  createdAt: ZonedDateTime = ZonedDateTime.now()
+  createdAt: ZonedDateTime = ZonedDateTime.now(),
   id: Int = 0
 )
 

--- a/core-models/src/main/scala/com/blackfynn/models/WebhookEventSubscription.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/WebhookEventSubscription.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+
+final case class WebhookEventSubcription(
+  webhookId: Int,
+  webhookEventTypeId: Int,
+  id: Int = 0
+)
+
+object WebhookEventSubcription {
+  implicit val decoder: Decoder[WebhookEventSubcription] = deriveDecoder[WebhookEventSubcription]
+  implicit val encoder: Encoder[WebhookEventSubcription] = deriveEncoder[WebhookEventSubcription]
+
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled = (this.apply _).tupled
+}

--- a/core-models/src/main/scala/com/blackfynn/models/WebhookEventSubscription.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/WebhookEventSubscription.scala
@@ -26,8 +26,10 @@ final case class WebhookEventSubcription(
 )
 
 object WebhookEventSubcription {
-  implicit val decoder: Decoder[WebhookEventSubcription] = deriveDecoder[WebhookEventSubcription]
-  implicit val encoder: Encoder[WebhookEventSubcription] = deriveEncoder[WebhookEventSubcription]
+  implicit val decoder: Decoder[WebhookEventSubcription] =
+    deriveDecoder[WebhookEventSubcription]
+  implicit val encoder: Encoder[WebhookEventSubcription] =
+    deriveEncoder[WebhookEventSubcription]
 
   /*
    * This is required by slick when using a companion object on a case

--- a/core-models/src/main/scala/com/blackfynn/models/WebhookEventType.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/WebhookEventType.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+
+final case class WebhookEventType(
+  eventName: String,
+  id: Int = 0
+)
+
+object WebhookEventType {
+  implicit val decoder: Decoder[WebhookEventType] = deriveDecoder[WebhookEventType]
+  implicit val encoder: Encoder[WebhookEventType] = deriveEncoder[WebhookEventType]
+
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled = (this.apply _).tupled
+}

--- a/core-models/src/main/scala/com/blackfynn/models/WebhookEventType.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/WebhookEventType.scala
@@ -19,14 +19,13 @@ package com.pennsieve.models
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
-final case class WebhookEventType(
-  eventName: String,
-  id: Int = 0
-)
+final case class WebhookEventType(eventName: String, id: Int = 0)
 
 object WebhookEventType {
-  implicit val decoder: Decoder[WebhookEventType] = deriveDecoder[WebhookEventType]
-  implicit val encoder: Encoder[WebhookEventType] = deriveEncoder[WebhookEventType]
+  implicit val decoder: Decoder[WebhookEventType] =
+    deriveDecoder[WebhookEventType]
+  implicit val encoder: Encoder[WebhookEventType] =
+    deriveEncoder[WebhookEventType]
 
   /*
    * This is required by slick when using a companion object on a case

--- a/core-models/src/main/scala/com/blackfynn/models/WebhookStatistic.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/WebhookStatistic.scala
@@ -29,8 +29,10 @@ final case class WebhookStatistic(
 )
 
 object WebhookStatistic {
-  implicit val decoder: Decoder[WebhookStatistic] = deriveDecoder[WebhookStatistic]
-  implicit val encoder: Encoder[WebhookStatistic] = deriveEncoder[WebhookStatistic]
+  implicit val decoder: Decoder[WebhookStatistic] =
+    deriveDecoder[WebhookStatistic]
+  implicit val encoder: Encoder[WebhookStatistic] =
+    deriveEncoder[WebhookStatistic]
 
   /*
    * This is required by slick when using a companion object on a case

--- a/core-models/src/main/scala/com/blackfynn/models/WebhookStatistic.scala
+++ b/core-models/src/main/scala/com/blackfynn/models/WebhookStatistic.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import java.time.ZonedDateTime
+import io.circe.java8.time._
+
+final case class WebhookStatistic(
+  webhookId: Int,
+  successes: Int = 0,
+  failures: Int = 0,
+  date: ZonedDateTime = ZonedDateTime.now()
+)
+
+object WebhookStatistic {
+  implicit val decoder: Decoder[WebhookStatistic] = deriveDecoder[WebhookStatistic]
+  implicit val encoder: Encoder[WebhookStatistic] = deriveEncoder[WebhookStatistic]
+
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled = (this.apply _).tupled
+}

--- a/core/src/main/scala/com/blackfynn/db/DatasetIntegrationsTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/DatasetIntegrationsTable.scala
@@ -23,23 +23,20 @@ import java.time.ZonedDateTime
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-final class DatasetIntegrationsTable(schema: String, tag: Tag) extends Table[DatasetIntegration](tag, Some(schema), "dataset_integrations") {
+final class DatasetIntegrationsTable(schema: String, tag: Tag)
+    extends Table[DatasetIntegration](tag, Some(schema), "dataset_integrations") {
 
   // set by the database
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
   def webhookId = column[Int]("webhook_id")
   def datasetId = column[Int]("dataset_id")
   def enabledBy = column[Int]("enabled_by")
-  def enabledOn = column[ZonedDateTime]("enabled_on", O.AutoInc) // set by the database on insert
+  def enabledOn =
+    column[ZonedDateTime]("enabled_on", O.AutoInc) // set by the database on insert
 
   def * =
-    (
-      webhookId,
-      datasetId,
-      enabledBy,
-      enabledOn,
-      id
-    ).mapTo[DatasetIntegration]
+    (webhookId, datasetId, enabledBy, enabledOn, id).mapTo[DatasetIntegration]
 }
 
-class DatasetIntegrationsMapper(val organization: Organization) extends TableQuery(new DatasetIntegrationsTable(organization.schemaId, _))
+class DatasetIntegrationsMapper(val organization: Organization)
+    extends TableQuery(new DatasetIntegrationsTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/DatasetIntegrationsTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/DatasetIntegrationsTable.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import com.pennsieve.traits.PostgresProfile.api._
+import com.pennsieve.models._
+
+import java.time.ZonedDateTime
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+final class DatasetIntegrationsTable(schema: String, tag: Tag) extends Table[DatasetIntegration](tag, Some(schema), "dataset_integrations") {
+
+  // set by the database
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def webhookId = column[Int]("webhook_id")
+  def datasetId = column[Int]("dataset_id")
+  def enabledBy = column[Int]("enabled_by")
+  def enabledOn = column[ZonedDateTime]("enabled_on", O.AutoInc) // set by the database on insert
+
+  def * =
+    (
+      webhookId,
+      datasetId,
+      enabledBy,
+      enabledOn,
+      id
+    ).mapTo[DatasetIntegration]
+}
+
+class DatasetIntegrationsMapper(val organization: Organization) extends TableQuery(new DatasetIntegrationsTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhookEventSubcriptionsTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhookEventSubcriptionsTable.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import com.pennsieve.traits.PostgresProfile.api._
+import com.pennsieve.models._
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+final class WebhookEventSubcriptionsTable(schema: String, tag: Tag) extends Table[WebhookEventSubcription](tag, Some(schema), "webhook_event_subscriptions") {
+
+  // set by the database
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def webhookId = column[Int]("webhook_id")
+  def webhookEventTypeId = column[Int]("webhook_event_type_id")
+
+  def * =
+    (
+      webhookId,
+      webhookEventTypeId,
+      id
+    ).mapTo[WebhookEventSubcription]
+}
+
+class WebhookEventSubcriptionsMapper(val organization: Organization) extends TableQuery(new WebhookEventSubcriptionsTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhookEventSubcriptionsTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhookEventSubcriptionsTable.scala
@@ -21,7 +21,12 @@ import com.pennsieve.models._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-final class WebhookEventSubcriptionsTable(schema: String, tag: Tag) extends Table[WebhookEventSubcription](tag, Some(schema), "webhook_event_subscriptions") {
+final class WebhookEventSubcriptionsTable(schema: String, tag: Tag)
+    extends Table[WebhookEventSubcription](
+      tag,
+      Some(schema),
+      "webhook_event_subscriptions"
+    ) {
 
   // set by the database
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
@@ -29,11 +34,10 @@ final class WebhookEventSubcriptionsTable(schema: String, tag: Tag) extends Tabl
   def webhookEventTypeId = column[Int]("webhook_event_type_id")
 
   def * =
-    (
-      webhookId,
-      webhookEventTypeId,
-      id
-    ).mapTo[WebhookEventSubcription]
+    (webhookId, webhookEventTypeId, id).mapTo[WebhookEventSubcription]
 }
 
-class WebhookEventSubcriptionsMapper(val organization: Organization) extends TableQuery(new WebhookEventSubcriptionsTable(organization.schemaId, _))
+class WebhookEventSubcriptionsMapper(val organization: Organization)
+    extends TableQuery(
+      new WebhookEventSubcriptionsTable(organization.schemaId, _)
+    )

--- a/core/src/main/scala/com/blackfynn/db/WebhookEventTypesTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhookEventTypesTable.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import com.pennsieve.traits.PostgresProfile.api._
+import com.pennsieve.models._
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+final class WebhookEventTypesTable(schema: String, tag: Tag) extends Table[WebhookEventType](tag, Some(schema), "webhook_event_types") {
+
+  // set by the database
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def eventName = column[String]("event_name")
+
+  def * =
+    (
+      eventName,
+      id
+    ).mapTo[WebhookEventType]
+}
+
+class WebhookEventTypesMapper(val organization: Organization) extends TableQuery(new WebhookEventTypesTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhookEventTypesTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhookEventTypesTable.scala
@@ -21,17 +21,16 @@ import com.pennsieve.models._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-final class WebhookEventTypesTable(schema: String, tag: Tag) extends Table[WebhookEventType](tag, Some(schema), "webhook_event_types") {
+final class WebhookEventTypesTable(schema: String, tag: Tag)
+    extends Table[WebhookEventType](tag, Some(schema), "webhook_event_types") {
 
   // set by the database
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
   def eventName = column[String]("event_name")
 
   def * =
-    (
-      eventName,
-      id
-    ).mapTo[WebhookEventType]
+    (eventName, id).mapTo[WebhookEventType]
 }
 
-class WebhookEventTypesMapper(val organization: Organization) extends TableQuery(new WebhookEventTypesTable(organization.schemaId, _))
+class WebhookEventTypesMapper(val organization: Organization)
+    extends TableQuery(new WebhookEventTypesTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhookStatisticsTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhookStatisticsTable.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import com.pennsieve.traits.PostgresProfile.api._
+import com.pennsieve.models._
+
+import java.time.ZonedDateTime
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+final class WebhookStatisticsTable(schema: String, tag: Tag) extends Table[WebhookStatistic](tag, Some(schema), "webhook_statistics") {
+
+  // set by the database
+  def webhookId = column[Int]("webhook_id", O.PrimaryKey)
+  def successes = column[Int]("successes") = 0
+  def failures = column[Int]("failures") = 0
+  def date = column[ZonedDateTime]("date", O.AutoInc) // set by the database on insert
+
+  def * =
+    (
+      webhookId,
+      successes,
+      failures,
+      date,
+      id
+    ).mapTo[WebhookStatistic]
+}
+
+class WebhookStatisticsMapper(val organization: Organization) extends TableQuery(new WebhookStatisticsTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhookStatisticsTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhookStatisticsTable.scala
@@ -23,22 +23,19 @@ import java.time.ZonedDateTime
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-final class WebhookStatisticsTable(schema: String, tag: Tag) extends Table[WebhookStatistic](tag, Some(schema), "webhook_statistics") {
+final class WebhookStatisticsTable(schema: String, tag: Tag)
+    extends Table[WebhookStatistic](tag, Some(schema), "webhook_statistics") {
 
   // set by the database
   def webhookId = column[Int]("webhook_id", O.PrimaryKey)
-  def successes = column[Int]("successes") = 0
-  def failures = column[Int]("failures") = 0
-  def date = column[ZonedDateTime]("date", O.AutoInc) // set by the database on insert
+  def successes = column[Int]("successes", O.Default(0))
+  def failures = column[Int]("failures", O.Default(0))
+  def date =
+    column[ZonedDateTime]("date", O.AutoInc) // set by the database on insert
 
   def * =
-    (
-      webhookId,
-      successes,
-      failures,
-      date,
-      id
-    ).mapTo[WebhookStatistic]
+    (webhookId, successes, failures, date).mapTo[WebhookStatistic]
 }
 
-class WebhookStatisticsMapper(val organization: Organization) extends TableQuery(new WebhookStatisticsTable(organization.schemaId, _))
+class WebhookStatisticsMapper(val organization: Organization)
+    extends TableQuery(new WebhookStatisticsTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhooksTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhooksTable.scala
@@ -23,7 +23,8 @@ import java.time.ZonedDateTime
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-final class WebhooksTable(schema: String, tag: Tag) extends Table[Webhook](tag, Some(schema), "webhooks") {
+final class WebhooksTable(schema: String, tag: Tag)
+    extends Table[Webhook](tag, Some(schema), "webhooks") {
 
   // set by the database
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
@@ -37,7 +38,8 @@ final class WebhooksTable(schema: String, tag: Tag) extends Table[Webhook](tag, 
   def isDefault = column[Boolean]("is_default")
   def isDisabled = column[Boolean]("is_disabled")
   def createdBy = column[Option[Int]]("created_by")
-  def createdAt = column[ZonedDateTime]("created_at", O.AutoInc) // set by the database on insert
+  def createdAt =
+    column[ZonedDateTime]("created_at", O.AutoInc) // set by the database on insert
 
   def * =
     (
@@ -56,4 +58,5 @@ final class WebhooksTable(schema: String, tag: Tag) extends Table[Webhook](tag, 
     ).mapTo[Webhook]
 }
 
-class WebhooksMapper(val organization: Organization) extends TableQuery(new WebhooksTable(organization.schemaId, _))
+class WebhooksMapper(val organization: Organization)
+    extends TableQuery(new WebhooksTable(organization.schemaId, _))

--- a/core/src/main/scala/com/blackfynn/db/WebhooksTable.scala
+++ b/core/src/main/scala/com/blackfynn/db/WebhooksTable.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import com.pennsieve.traits.PostgresProfile.api._
+import com.pennsieve.models._
+
+import java.time.ZonedDateTime
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+final class WebhooksTable(schema: String, tag: Tag) extends Table[Webhook](tag, Some(schema), "webhooks") {
+
+  // set by the database
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def apiUrl = column[String]("api_url")
+  def imageUrl = column[Option[String]]("image_url")
+  def description = column[String]("description")
+  def secret = column[String]("secret")
+  def name = column[String]("name")
+  def displayName = column[String]("display_name")
+  def isPrivate = column[Boolean]("is_private")
+  def isDefault = column[Boolean]("is_default")
+  def isDisabled = column[Boolean]("is_disabled")
+  def createdBy = column[Option[Int]]("created_by")
+  def createdAt = column[ZonedDateTime]("created_at", O.AutoInc) // set by the database on insert
+
+  def * =
+    (
+      apiUrl,
+      imageUrl,
+      description,
+      secret,
+      name,
+      displayName,
+      isPrivate,
+      isDefault,
+      isDisabled,
+      createdBy,
+      createdAt,
+      id
+    ).mapTo[Webhook]
+}
+
+class WebhooksMapper(val organization: Organization) extends TableQuery(new WebhooksTable(organization.schemaId, _))


### PR DESCRIPTION
## Changes Proposed
Added models and tables for the new tables introduced in #91. Added Mappers for each as well to be filled in with db query functions in the future.

## Ticket
[y5bhv0](https://app.clickup.com/t/y5bhv0)

## Schema
![pennsieve_integration_service_db_schema](https://user-images.githubusercontent.com/55994045/122115025-f66bbb80-cdf1-11eb-8ccd-d30898e12159.jpg)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
