### PR TITLE
Fix disabled flag on webhook creation

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/TestWebhooksController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestWebhooksController.scala
@@ -47,33 +47,18 @@ class TestWebhooksController extends BaseApiTest with DataSetTestMixin {
 
     get(s"/${webhook.id}", headers = authorizationHeader(loggedInJwt)) {
       status should equal(200)
-      (parsedBody \ "id").extract[Int] should equal(webhook.id)
-      (parsedBody \ "apiUrl").extract[String] should equal(webhook.apiUrl)
-      (parsedBody \ "imageUrl").extract[String] should equal(
-        webhook.imageUrl.get
-      )
-      (parsedBody \ "description").extract[String] should equal(
-        webhook.description
-      )
-      (parsedBody \ "name").extract[String] should equal(webhook.name)
-      (parsedBody \ "displayName").extract[String] should equal(
-        webhook.displayName
-      )
-      (parsedBody \ "isPrivate").extract[Boolean] should equal(
-        webhook.isPrivate
-      )
-      (parsedBody \ "isDefault").extract[Boolean] should equal(
-        webhook.isDefault
-      )
-      (parsedBody \ "isDisabled").extract[Boolean] should equal(
-        webhook.isDisabled
-      )
-      (parsedBody \ "createdBy").extract[Int] should equal(
-        webhook.createdBy.get
-      )
-      (parsedBody \ "createdAt").extract[ZonedDateTime] should equal(
-        webhook.createdAt
-      )
+      val resp = parsedBody.extract[WebhookDTO]
+      resp.id should equal(webhook.id)
+      resp.apiUrl should equal(webhook.apiUrl)
+      resp.imageUrl should equal(Some(webhook.imageUrl.get))
+      resp.description should equal(webhook.description)
+      resp.name should equal(webhook.name)
+      resp.displayName should equal(webhook.displayName)
+      resp.isPrivate should equal(webhook.isPrivate)
+      resp.isDefault should equal(webhook.isDefault)
+      resp.isDisabled should equal(false)
+      resp.createdBy should equal(Some(webhook.createdBy.get))
+      resp.createdAt should equal(webhook.createdAt)
     }
   }
 
@@ -107,6 +92,7 @@ class TestWebhooksController extends BaseApiTest with DataSetTestMixin {
       webhook.displayName should equal("Test Webhook")
       webhook.isPrivate should equal(false)
       webhook.isDefault should equal(true)
+      webhook.isDisabled should equal(false)
       webhook.createdBy should equal(Some(loggedInUser.id))
     }
   }

--- a/api/src/test/scala/com/pennsieve/api/TestWebhooksController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestWebhooksController.scala
@@ -94,6 +94,11 @@ class TestWebhooksController extends BaseApiTest with DataSetTestMixin {
       webhook.isDefault should equal(true)
       webhook.isDisabled should equal(false)
       webhook.createdBy should equal(Some(loggedInUser.id))
+
+      get(s"/${webhook.id}", headers = authorizationHeader(loggedInJwt)) {
+        status should equal(200)
+        parsedBody.extract[WebhookDTO].id shouldBe (webhook.id)
+      }
     }
   }
 

--- a/core/src/main/scala/com/pennsieve/managers/WebhookManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/WebhookManager.scala
@@ -85,7 +85,7 @@ class WebhookManager(
         displayName.trim,
         isPrivate,
         isDefault,
-        true,
+        false,
         Some(createdBy)
       )
 


### PR DESCRIPTION
## Changes Proposed
Quick fix relating to #95, where the `isDisabled` flag is erroneously set to `true` on webhook creation. Should be `false`. Updated tests to reflect this change.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
