### PR TITLE
refactor created by column to non nullable

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/TestWebhooksController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestWebhooksController.scala
@@ -57,7 +57,7 @@ class TestWebhooksController extends BaseApiTest with DataSetTestMixin {
       resp.isPrivate should equal(webhook.isPrivate)
       resp.isDefault should equal(webhook.isDefault)
       resp.isDisabled should equal(false)
-      resp.createdBy should equal(Some(webhook.createdBy.get))
+      resp.createdBy should equal(webhook.createdBy)
       resp.createdAt should equal(webhook.createdAt)
     }
   }
@@ -118,7 +118,7 @@ class TestWebhooksController extends BaseApiTest with DataSetTestMixin {
       webhook.isPrivate should equal(false)
       webhook.isDefault should equal(true)
       webhook.isDisabled should equal(false)
-      webhook.createdBy should equal(Some(loggedInUser.id))
+      webhook.createdBy should equal(loggedInUser.id)
 
       get(s"/${webhook.id}", headers = authorizationHeader(loggedInJwt)) {
         status should equal(200)

--- a/core-models/src/main/scala/com/pennsieve/dtos/WebhookDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/WebhookDTO.scala
@@ -31,7 +31,7 @@ final case class WebhookDTO(
   isPrivate: Boolean,
   isDefault: Boolean,
   isDisabled: Boolean,
-  createdBy: Option[Int],
+  createdBy: Int,
   createdAt: ZonedDateTime
 )
 

--- a/core-models/src/main/scala/com/pennsieve/models/Webhook.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/Webhook.scala
@@ -31,7 +31,7 @@ final case class Webhook(
   isPrivate: Boolean,
   isDefault: Boolean,
   isDisabled: Boolean,
-  createdBy: Option[Int],
+  createdBy: Int,
   createdAt: ZonedDateTime = ZonedDateTime.now(),
   id: Int = 0
 )

--- a/core/src/main/scala/com/pennsieve/db/WebhooksTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/WebhooksTable.scala
@@ -37,7 +37,7 @@ final class WebhooksTable(schema: String, tag: Tag)
   def isPrivate = column[Boolean]("is_private")
   def isDefault = column[Boolean]("is_default")
   def isDisabled = column[Boolean]("is_disabled")
-  def createdBy = column[Option[Int]]("created_by")
+  def createdBy = column[Int]("created_by")
   def createdAt =
     column[ZonedDateTime]("created_at", O.AutoInc) // set by the database on insert
 

--- a/core/src/main/scala/com/pennsieve/managers/WebhookManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/WebhookManager.scala
@@ -86,7 +86,7 @@ class WebhookManager(
         isPrivate,
         isDefault,
         false,
-        Some(createdBy)
+        createdBy
       )
 
       createdWebhook = (webhooksMapper returning webhooksMapper) += row
@@ -114,7 +114,7 @@ class WebhookManager(
       userId = actor.id
 
       _ <- checkOrErrorT[CoreError](
-        !(webhook.createdBy.getOrElse(userId) != userId && webhook.isPrivate)
+        !(webhook.createdBy != userId && webhook.isPrivate)
       )(
         InvalidAction(
           s"user ${userId} does not have access to webhook ${webhook.id}"

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20210629112614__alter_webhooks_created_by_not_null.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20210629112614__alter_webhooks_created_by_not_null.sql
@@ -1,0 +1,12 @@
+ALTER TABLE webhooks
+  DROP CONSTRAINT webhooks_created_by_fkey;
+
+ALTER TABLE webhooks
+  ADD CONSTRAINT webhooks_created_by_fkey
+  FOREIGN KEY (created_by)
+  REFERENCES pennsieve.users(id)
+  ON DELETE RESTRICT;
+
+ALTER TABLE webhooks
+  ALTER COLUMN created_by
+  SET NOT NULL;


### PR DESCRIPTION
## Changes Proposed
The `createdBy` column in the webhooks table was originally nullable. This should not be the case, the id of the user that created the webhook should always be filled in.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
