### PR TITLE
allowing revision when released

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetPublishingHelper.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetPublishingHelper.scala
@@ -703,7 +703,7 @@ case object DataSetPublishingHelper extends LazyLogging {
       _ <- checkOrError[CoreError](
         if (requestedType == PublicationType.Revision)
           lastCompletedPublicationType.exists(
-            _ in Seq(PublicationType.Publication, PublicationType.Revision)
+            _ in Seq(PublicationType.Publication, PublicationType.Revision, PublicationType.Release)
           )
         else true
       )(PredicateError(s"Only published datasets can be revised"))
@@ -712,7 +712,7 @@ case object DataSetPublishingHelper extends LazyLogging {
       _ <- checkOrError[CoreError](
         if (requestedType == PublicationType.Embargo)
           !lastCompletedPublicationType.exists(
-            _ in Seq(PublicationType.Publication, PublicationType.Revision)
+            _ in Seq(PublicationType.Publication, PublicationType.Revision, PublicationType.Release)
           )
         else true
       )(PredicateError(s"May not embargo dataset that is currently published"))


### PR DESCRIPTION
## Changes Proposed
Fix bug that does not allow users to create a dataset revision when the last successful publishing action is the "release" of an embargoed dataset.

Fix bug that did not check when user tries to create embargoed dataset if the dataset was previously released from embargo and therefore already exists

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
