### PR TITLE
use filename from DB instead of S3 name when downloading file

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -919,7 +919,8 @@ class PackagesController(
                       if (ext == "") p.packageName
                       else s"${p.packageName}.${ext}"
                     } else {
-                      FilenameUtils.getName(p.s3Key)
+                      p.fileName
+//                      FilenameUtils.getName(p.s3Key)
                     }
                   },
                   packageName = p.packageName,


### PR DESCRIPTION
## Changes Proposed
use filename from DB instead of S3 name when downloading file
