### PR TITLE
trim length s3_keys

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/FilesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/FilesController.scala
@@ -145,7 +145,7 @@ object FilesController {
       s"${FilesController
         .uploadsDirectory(user, importId, usingUploadService)}${cleanS3Key(file)}"
     } else {
-      file
+      cleanS3Key(file)
     }
   }
 

--- a/core-models/src/main/scala/com/pennsieve/models/utilities.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/utilities.scala
@@ -16,33 +16,22 @@
 
 package com.pennsieve.models
 
-import com.google.common.net.UrlEscapers
 import org.apache.commons.io.FilenameUtils
 
 package object Utilities {
 
+  /**
+    * isNameValid should check if file/package name is valid.
+    * Currently, we do not have any restrictions. Escaping for S3 is handled
+    * separately with cleanS3Key method in core-models/Utilities
+    *
+    * TODO: Add meaningful restrictions such as length and maybe path characters?
+    *
+    * @param name
+    * @return
+    */
   def isNameValid(name: String): Boolean = {
-    var AuthorizedCharacters =
-      "^[\\p{L}\\p{N}() %*_\\-'.!]{1,255}$".r
-    //matches all "letter" characters from unicode plus digits and some special characters that are allowed by S3 for keys
-
-    val allCharactersValid: Boolean =
-      AuthorizedCharacters.pattern
-        .matcher(name)
-        .matches
-
-    val multipleContiguousSpaces = " {2,}".r
-
-    val severalWhiteSpacesInARow = multipleContiguousSpaces.findFirstIn(name)
-
-    val ForbiddenPercentSign = "%(?![2-9A-F][0-9A-F])".r
-    //negative lookahead: this regex will match any % that is not followed by an hexadecimal code for an html entity (between 20 and FF)
-
-    val badPercentSignDetected
-      : Option[String] = ForbiddenPercentSign findFirstIn name
-    //since we're using a negative lookahead, the elements won't be captured the same way and we cannot use the same method to test if the regex found something
-
-    allCharactersValid && badPercentSignDetected.isEmpty && severalWhiteSpacesInARow.isEmpty
+    true
   }
 
   def getPennsieveExtension(fileName: String): String = {
@@ -85,62 +74,66 @@ package object Utilities {
       "%2E"
     } else if (key == "..")
       "%2E%2E"
-    else
-      """[^\p{L}\p{N}()*_ \-'.!]""".r
-        .replaceAllIn(key, "_")
-        .replaceAll("\\s+", " ")
-        .trim
+    else {
+      val result =
+        """[^\p{L}\p{N}()*_ \-'.!]""".r
+          .replaceAllIn(key, "_")
+          .replaceAll("\\s+", " ")
+          .trim
+
+      result.substring(0, Math.min(result.length, 128))
+    }
 
   }
 
 //    key.replaceAll("[^a-zA-Z0-9./@-]", "_")
 
-  def escapeName(name: String): String = {
-    if (name == ".")
-      "%2E"
-    else if (name == "..")
-      "%2E%2E"
-    else if (isNameValid(name))
-      name
-    else {
-      val result = "\\s+".r
-        .replaceAllIn(name, " ")
-        // escape % signs
-        .replaceAll("%(?![2-9A-F][0-9A-F])", "%25")
-        // plus sign are not allowed by S3
-        .replaceAll("\\+", "%2B")
-        // tildes are not allowed by S3
-        .replaceAll("~", "%7E")
-        // the following characters  are not allowed by our naming convention
-        .replaceAll(":", "%3A")
-        .replaceAll(",", "%2C")
-        .replaceAll("@", "%40")
-        .replaceAll("\\$", "%24")
-        .replaceAll("&", "%26")
-        .replaceAll("=", "%3D")
-        .replaceAll(";", "%3B")
-        .replaceAll("/", "%2F")
-        .replaceAll("\\{", "%7B")
-        .replaceAll("}", "%7D")
-        .replaceAll("\\[", "%5B")
-        .replaceAll("]", "%5D")
-        .replaceAll("\\|", "%7C")
-        .replaceAll("#", "%23")
-        .replaceAll("\\^", "%5E")
-        .replaceAll("<", "%3C")
-        .replaceAll(">", "%3E")
-        .replaceAll("\\?", "%3F")
-        .replaceAll("\\\\", "%5C")
-        .replaceAll("`", "%60")
-
-      // Replace % characters not valid escape codes.
-      val escapedString = "^[^\\p{L}\\p{N}() %*_\\-'.!]".r
-        .replaceAllIn(result, "_")
-
-      //trim string if exceeds 255 characters
-      escapedString.substring(0, Math.min(escapedString.length, 255))
-
-    }
-
-  }
+//  def escapeName(name: String): String = {
+//    if (name == ".")
+//      "%2E"
+//    else if (name == "..")
+//      "%2E%2E"
+//    else if (isNameValid(name))
+//      name
+//    else {
+//      val result = "\\s+".r
+//        .replaceAllIn(name, " ")
+//        // escape % signs
+//        .replaceAll("%(?![2-9A-F][0-9A-F])", "%25")
+//        // plus sign are not allowed by S3
+//        .replaceAll("\\+", "%2B")
+//        // tildes are not allowed by S3
+//        .replaceAll("~", "%7E")
+//        // the following characters  are not allowed by our naming convention
+//        .replaceAll(":", "%3A")
+//        .replaceAll(",", "%2C")
+//        .replaceAll("@", "%40")
+//        .replaceAll("\\$", "%24")
+//        .replaceAll("&", "%26")
+//        .replaceAll("=", "%3D")
+//        .replaceAll(";", "%3B")
+//        .replaceAll("/", "%2F")
+//        .replaceAll("\\{", "%7B")
+//        .replaceAll("}", "%7D")
+//        .replaceAll("\\[", "%5B")
+//        .replaceAll("]", "%5D")
+//        .replaceAll("\\|", "%7C")
+//        .replaceAll("#", "%23")
+//        .replaceAll("\\^", "%5E")
+//        .replaceAll("<", "%3C")
+//        .replaceAll(">", "%3E")
+//        .replaceAll("\\?", "%3F")
+//        .replaceAll("\\\\", "%5C")
+//        .replaceAll("`", "%60")
+//
+//      // Replace % characters not valid escape codes.
+//      val escapedString = "^[^\\p{L}\\p{N}() %*_\\-'.!]".r
+//        .replaceAllIn(result, "_")
+//
+//      //trim string if exceeds 255 characters
+//      escapedString.substring(0, Math.min(escapedString.length, 255))
+//
+//    }
+//
+//  }
 }

--- a/core-models/src/test/scala/com/pennsieve/models/utilities/TestUtilities.scala
+++ b/core-models/src/test/scala/com/pennsieve/models/utilities/TestUtilities.scala
@@ -65,88 +65,92 @@ class TestUtilities extends WordSpecLike with Matchers {
       )
       val crazyFileName =
         "@ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo .png"
-      Utilities.cleanS3Key(crazyFileName) shouldBe Utilities.escapeName(
+      Utilities.cleanS3Key(crazyFileName) shouldBe Utilities.cleanS3Key(
         Utilities.cleanS3Key(crazyFileName)
       )
     }
 
-  }
-
-  "escapeName" should {
-    "preserve spaces in escaped keys" in {
-      Utilities.escapeName("My file") shouldBe "My file"
-    }
-
     "trim long length" in {
-      Utilities.escapeName("1234567890" * 26) shouldBe "1234567890" * 25 + "12345"
-    }
-
-    "remove bad characters" in {
-      Utilities.escapeName("my/file") shouldBe "my%2Ffile"
-      Utilities.escapeName("my~file") shouldBe "my%7Efile"
-      Utilities.escapeName("many     spaces") shouldBe "many spaces"
-      Utilities.escapeName("file+1") shouldBe "file%2B1"
-      Utilities.escapeName("file, 1") shouldBe "file%2C 1"
-      Utilities.escapeName("file: 1") shouldBe "file%3A 1"
-      Utilities.escapeName("file; 1") shouldBe "file%3B 1"
-      Utilities.escapeName("@#$%^&+={}|[]:;<>?/\\,") shouldBe "%40%23%24%25%5E%26%2B%3D%7B%7D%7C%5B%5D%3A%3B%3C%3E%3F%2F%5C%2C"
-
-    }
-
-    "preserve allowed S3 characters" in {
-      Utilities.escapeName("My (file)") shouldBe "My (file)"
-      Utilities.escapeName("file!") shouldBe "file!"
-      Utilities.escapeName("fi-le") shouldBe "fi-le"
-      Utilities.escapeName("fi_le") shouldBe "fi_le"
-      Utilities.escapeName("file.zip") shouldBe "file.zip"
-      Utilities.escapeName("'file'") shouldBe "'file'"
-      Utilities.escapeName("file* 1") shouldBe "file* 1"
-      Utilities.escapeName("() *_-'.!") shouldBe "() *_-'.!"
-      Utilities.escapeName("Å") shouldBe "Å" //unicode test
-      Utilities.escapeName("%20+ %20+ %20+ %20+") shouldBe "%20%2B %20%2B %20%2B %20%2B"
-      Utilities.escapeName("%2+") shouldBe "%252%2B"
-    }
-
-    "replace UNIX path special characters" in {
-      Utilities.escapeName(".") shouldBe "%2E"
-      Utilities.escapeName("..") shouldBe "%2E%2E"
-    }
-
-    "change invalid special characters into valid characters" in {
-      assert(
-        Utilities
-          .isNameValid(Utilities.escapeName("@#$%^&+={}|[]:;<>?/\\,")) == true
-      )
-    }
-
-    "be idempotent" in {
-      assert(
-        Utilities.escapeName("my+file") == Utilities
-          .escapeName(Utilities.escapeName("my+file"))
-      )
-      val crazyFileName =
-        "@ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo .png"
-      Utilities.escapeName(crazyFileName) shouldBe Utilities.escapeName(
-        Utilities.escapeName(crazyFileName)
-      )
-
-    }
-  }
-
-  "isNameValid" should {
-    "be true for all valid special characters" in {
-      assert(
-        Utilities
-          .isNameValid(("( -_*.!)")) == true
-      )
-    }
-
-    "work for names up to 255 chars" in {
-      assert(Utilities.isNameValid("1234567890" * 25 + "12345") == true)
-      assert(Utilities.isNameValid("1234567890" * 25 + "123456") == false)
+      Utilities.cleanS3Key("1234567890" * 13) shouldBe "1234567890" * 12 + "12345678"
     }
 
   }
+
+//  "escapeName" should {
+//    "preserve spaces in escaped keys" in {
+//      Utilities.escapeName("My file") shouldBe "My file"
+//    }
+//
+//    "trim long length" in {
+//      Utilities.escapeName("1234567890" * 26) shouldBe "1234567890" * 25 + "12345"
+//    }
+//
+//    "remove bad characters" in {
+//      Utilities.escapeName("my/file") shouldBe "my%2Ffile"
+//      Utilities.escapeName("my~file") shouldBe "my%7Efile"
+//      Utilities.escapeName("many     spaces") shouldBe "many spaces"
+//      Utilities.escapeName("file+1") shouldBe "file%2B1"
+//      Utilities.escapeName("file, 1") shouldBe "file%2C 1"
+//      Utilities.escapeName("file: 1") shouldBe "file%3A 1"
+//      Utilities.escapeName("file; 1") shouldBe "file%3B 1"
+//      Utilities.escapeName("@#$%^&+={}|[]:;<>?/\\,") shouldBe "%40%23%24%25%5E%26%2B%3D%7B%7D%7C%5B%5D%3A%3B%3C%3E%3F%2F%5C%2C"
+//
+//    }
+//
+//    "preserve allowed S3 characters" in {
+//      Utilities.escapeName("My (file)") shouldBe "My (file)"
+//      Utilities.escapeName("file!") shouldBe "file!"
+//      Utilities.escapeName("fi-le") shouldBe "fi-le"
+//      Utilities.escapeName("fi_le") shouldBe "fi_le"
+//      Utilities.escapeName("file.zip") shouldBe "file.zip"
+//      Utilities.escapeName("'file'") shouldBe "'file'"
+//      Utilities.escapeName("file* 1") shouldBe "file* 1"
+//      Utilities.escapeName("() *_-'.!") shouldBe "() *_-'.!"
+//      Utilities.escapeName("Å") shouldBe "Å" //unicode test
+//      Utilities.escapeName("%20+ %20+ %20+ %20+") shouldBe "%20%2B %20%2B %20%2B %20%2B"
+//      Utilities.escapeName("%2+") shouldBe "%252%2B"
+//    }
+//
+//    "replace UNIX path special characters" in {
+//      Utilities.escapeName(".") shouldBe "%2E"
+//      Utilities.escapeName("..") shouldBe "%2E%2E"
+//    }
+//
+//    "change invalid special characters into valid characters" in {
+//      assert(
+//        Utilities
+//          .isNameValid(Utilities.escapeName("@#$%^&+={}|[]:;<>?/\\,")) == true
+//      )
+//    }
+//
+//    "be idempotent" in {
+//      assert(
+//        Utilities.escapeName("my+file") == Utilities
+//          .escapeName(Utilities.escapeName("my+file"))
+//      )
+//      val crazyFileName =
+//        "@ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo @ ! _ %20foo .png"
+//      Utilities.escapeName(crazyFileName) shouldBe Utilities.escapeName(
+//        Utilities.escapeName(crazyFileName)
+//      )
+//
+//    }
+//  }
+//
+//  "isNameValid" should {
+//    "be true for all valid special characters" in {
+//      assert(
+//        Utilities
+//          .isNameValid(("( -_*.!)")) == true
+//      )
+//    }
+//
+//    "work for names up to 255 chars" in {
+//      assert(Utilities.isNameValid("1234567890" * 25 + "12345") == true)
+//      assert(Utilities.isNameValid("1234567890" * 25 + "123456") == false)
+//    }
+//
+//  }
 
   "getPennsieveExtension" should {
     "return the proper extension" in {

--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -116,12 +116,12 @@ class PackageManager(datasetManager: DatasetManager) {
       _ <- FutureEitherHelpers.assert(name.trim.nonEmpty)(
         PredicateError("package name must not be empty")
       )
-//TODO: Update this to check for valid packageNames again. This should be different between packages and collections
-//      _ <- checkOrErrorT(isNameValid(name))(
-//        PredicateError(
-//          s"Invalid package name, please follow the naming conventions"
-//        )
-//      )
+
+      _ <- checkOrErrorT(isNameValid(name))(
+        PredicateError(
+          s"Invalid package name, please follow the naming conventions"
+        )
+      )
 
       createPackage = for {
         // If the package's name is taken use a generated recommendation
@@ -530,10 +530,11 @@ class PackageManager(datasetManager: DatasetManager) {
       )(ServiceError("a package must belong to the same dataset as its parent"))
 
       _ <- checkOrErrorT(
-        isNameValid(packageToUpdate.name) || old.name == packageToUpdate.name
+//        isNameValid(packageToUpdate.name) || old.name == packageToUpdate.name
+        old.name == packageToUpdate.name
       )(
         PredicateError(
-          s"Invalid package name, please follow the naming conventions"
+          s"Invalid package name, new name must be different than old name"
         )
       )
 


### PR DESCRIPTION
## Changes Proposed
* trim s3 names to be 128 chars or shorter
* Set checkValid name return to true as we don't limit names for files

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
