### PR TITLE
explicitly set name

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
@@ -190,6 +190,7 @@ object DatasetMetadata {
 }
 
 case class FileManifest(
+  name: String,
   path: String,
   size: Long,
   fileType: FileType,
@@ -197,7 +198,7 @@ case class FileManifest(
   id: Option[UUID] = None
 ) extends Ordered[FileManifest] {
 
-  def name: String = FilenameUtils.getName(path)
+//  def name: String = FilenameUtils.getName(path)
 
   // Order files lexicographically by path
   def compare(that: FileManifest) =

--- a/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
@@ -121,6 +121,29 @@ case class DatasetMetadataV4_0(
   pennsieveSchemaVersion: String = "4.0"
 ) extends DatasetMetadata
 
+case class DatasetMetadataV5_0(
+  pennsieveDatasetId: Int,
+  version: Int,
+  revision: Option[Int],
+  name: String,
+  description: String,
+  creator: PublishedContributor,
+  contributors: List[PublishedContributor],
+  sourceOrganization: String,
+  keywords: List[String],
+  datePublished: LocalDate,
+  license: Option[License],
+  `@id`: String, // DOI
+  publisher: String = "The University of Pennsylvania",
+  `@context`: String = "http://schema.org/",
+  `@type`: String = "Dataset",
+  schemaVersion: String = "http://schema.org/version/3.7/",
+  collections: Option[List[PublishedCollection]] = None,
+  relatedPublications: Option[List[PublishedExternalPublication]] = None,
+  files: List[FileManifest] = List.empty,
+  pennsieveSchemaVersion: String = "4.0"
+) extends DatasetMetadata
+
 object DatasetMetadataV4_0 {
   implicit val encoder: Encoder[DatasetMetadataV4_0] =
     deriveEncoder[DatasetMetadataV4_0]
@@ -198,7 +221,13 @@ case class FileManifest(
   id: Option[UUID] = None
 ) extends Ordered[FileManifest] {
 
-//  def name: String = FilenameUtils.getName(path)
+  def this(
+    path: String,
+    size: Long,
+    fileType: FileType,
+    sourcePackageId: Option[String]
+  ) =
+    this(FilenameUtils.getName(path), path, size, fileType, sourcePackageId)
 
   // Order files lexicographically by path
   def compare(that: FileManifest) =
@@ -209,6 +238,41 @@ case class FileManifest(
 object FileManifest {
   implicit val encoder: Encoder[FileManifest] =
     deriveEncoder[FileManifest].mapJson(_.mapObject(_.remove("id")))
-  implicit val decoder: Decoder[FileManifest] =
-    deriveDecoder[FileManifest]
+  implicit val decoder: Decoder[FileManifest] = new Decoder[FileManifest] {
+    final def apply(c: HCursor): Decoder.Result[FileManifest] =
+      for {
+        path <- c.downField("path").as[String]
+        name <- c.downField("name").as[Option[String]]
+        size <- c.downField("size").as[Long]
+        fileType <- c.downField("fileType").as[FileType]
+        sourcePackageId <- c.downField("sourcePackageId").as[Option[String]]
+        id <- c.downField("id").as[Option[UUID]]
+
+        mappedName = if (name.isEmpty) {
+          FilenameUtils.getName(path)
+        } else {
+          name.get
+        }
+      } yield {
+        new FileManifest(mappedName, path, size, fileType, sourcePackageId, id)
+      }
+  }
+
+  def apply(
+    /**
+      * Used in older versions of the schema.
+      */
+    path: String,
+    size: Long,
+    fileType: FileType,
+    sourcePackageId: Option[String]
+  ): FileManifest = {
+    FileManifest(
+      FilenameUtils.getName(path),
+      path,
+      size,
+      fileType,
+      sourcePackageId
+    )
+  }
 }

--- a/discover-publish/src/main/scala/com/pennsieve/publish/PackagesExport.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/PackagesExport.scala
@@ -64,6 +64,7 @@ object PackagesExport extends LazyLogging {
     Sink.fold(Nil: List[FileManifest])(
       (accum, action: CopyAction) =>
         FileManifest(
+          name = action.file.name,
           path = action.fileKey,
           size = action.file.size,
           fileType = action.file.fileType,

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -395,7 +395,15 @@ object Publish extends StrictLogging {
         .leftMap[CoreError](ThrowableError)
 
     } yield
-      (readmeKey, FileManifest(README_FILENAME,README_FILENAME, readmeSize, FileType.Markdown))
+      (
+        readmeKey,
+        FileManifest(
+          README_FILENAME,
+          README_FILENAME,
+          readmeSize,
+          FileType.Markdown
+        )
+      )
   }
 
   /**
@@ -414,7 +422,8 @@ object Publish extends StrictLogging {
     // size of metadata.json for the manifest, but we need the size
     // to be encoded in the JSON file before we can compute the size.
     // Set size to 0 for now, and revise it later.
-    val metadataManifest = FileManifest(METADATA_FILENAME,METADATA_FILENAME, 0, FileType.Json)
+    val metadataManifest =
+      FileManifest(METADATA_FILENAME, METADATA_FILENAME, 0, FileType.Json)
 
     val unsizedMetadata = DatasetMetadataV4_0(
       pennsieveDatasetId = container.publishedDatasetId,

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -331,6 +331,7 @@ object Publish extends StrictLogging {
         bannerKey,
         FileManifest(
           bannerName,
+          bannerName,
           bannerSize,
           FileExtensions.fileTypeMap(extension.toLowerCase)
         )
@@ -394,7 +395,7 @@ object Publish extends StrictLogging {
         .leftMap[CoreError](ThrowableError)
 
     } yield
-      (readmeKey, FileManifest(README_FILENAME, readmeSize, FileType.Markdown))
+      (readmeKey, FileManifest(README_FILENAME,README_FILENAME, readmeSize, FileType.Markdown))
   }
 
   /**
@@ -413,7 +414,7 @@ object Publish extends StrictLogging {
     // size of metadata.json for the manifest, but we need the size
     // to be encoded in the JSON file before we can compute the size.
     // Set size to 0 for now, and revise it later.
-    val metadataManifest = FileManifest(METADATA_FILENAME, 0, FileType.Json)
+    val metadataManifest = FileManifest(METADATA_FILENAME,METADATA_FILENAME, 0, FileType.Json)
 
     val unsizedMetadata = DatasetMetadataV4_0(
       pennsieveDatasetId = container.publishedDatasetId,

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -622,7 +622,7 @@ class TestPublish
       val pkg1 = createPackage(testUser, name = "pkg1")
       val file1 = createFile(
         pkg1,
-        name = "file",
+        name = "file1",
         s3Key = "key/file.txt",
         content = "data data",
         size = 1234
@@ -723,27 +723,32 @@ class TestPublish
           files = List(
             FileManifest(
               Publish.BANNER_FILENAME,
+              Publish.BANNER_FILENAME,
               bannerJpg.length,
               FileType.JPEG
             ),
             FileManifest(
               Publish.METADATA_FILENAME,
+              Publish.METADATA_FILENAME,
               metadata.getBytes("utf-8").length,
               FileType.Json
             ),
             FileManifest(
+              "file2",
               "files/pkg2/file2.dcm",
               2222,
               FileType.DICOM,
               Some(pkg2.nodeId)
             ),
             FileManifest(
+              "file3",
               "files/pkg2/file3.dcm",
               3333,
               FileType.DICOM,
               Some(pkg2.nodeId)
             ),
             FileManifest(
+              "file1",
               "files/pkg1.txt",
               1234,
               FileType.Text,
@@ -751,10 +756,12 @@ class TestPublish
             ),
             FileManifest(
               Publish.README_FILENAME,
+              Publish.README_FILENAME,
               readmeMarkdown.length,
               FileType.Markdown
             ),
             FileManifest(
+              "schema.json",
               "metadata/schema.json",
               schemaJson.length,
               FileType.Json
@@ -783,7 +790,7 @@ class TestPublish
       val pkg1 = createPackage(testUser, name = "pkg1")
       val file1 = createFile(
         pkg1,
-        name = "file",
+        name = "file1",
         s3Key = "key/file.txt",
         content = "data data",
         size = 1234
@@ -882,27 +889,32 @@ class TestPublish
           files = List(
             FileManifest(
               Publish.BANNER_FILENAME,
+              Publish.BANNER_FILENAME,
               bannerJpg.length,
               FileType.JPEG
             ),
             FileManifest(
               Publish.METADATA_FILENAME,
+              Publish.METADATA_FILENAME,
               metadata.getBytes("utf-8").length,
               FileType.Json
             ),
             FileManifest(
+              "file2",
               "files/pkg2/file2.dcm",
               2222,
               FileType.DICOM,
               Some(pkg2.nodeId)
             ),
             FileManifest(
+              "file3",
               "files/pkg2/file3.dcm",
               3333,
               FileType.DICOM,
               Some(pkg2.nodeId)
             ),
             FileManifest(
+              "file1",
               "files/pkg1.txt",
               1234,
               FileType.Text,
@@ -910,10 +922,12 @@ class TestPublish
             ),
             FileManifest(
               Publish.README_FILENAME,
+              Publish.README_FILENAME,
               readmeMarkdown.length,
               FileType.Markdown
             ),
             FileManifest(
+              "schema.json",
               "metadata/schema.json",
               schemaJson.length,
               FileType.Json


### PR DESCRIPTION
## Changes Proposed
* Explicitely set name of file manifest during publication instead of deriving from s3path


## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
