### PR TITLE
FIX: attach Cognito IAM Policy which permits AdminCreateUser to user_pool_2

### DIFF
--- a/api/terraform/iam.tf
+++ b/api/terraform/iam.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "cognito_iam_policy_document" {
     ]
 
     resources = [
-      data.terraform_remote_state.authentication_service.outputs.user_pool_arn,
+      data.terraform_remote_state.authentication_service.outputs.user_pool_2_arn,
     ]
   }
 


### PR DESCRIPTION
## Changes Proposed
Attach the Cognito IAM Policy which permits the AdminCreateUser action to act on the new user pool (authentication-service/user-pool-2)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
