### PR TITLE
use insecure container for deleting integration token

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/FilesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/FilesController.scala
@@ -671,7 +671,7 @@ class FilesController(
     : OperationBuilder = (apiOperation[PreviewPackageResponse](
     "getPackagePreviews"
   )
-    summary "returns packages that will be created from a given list of files"
+    summary "DEPRECATED: returns packages that will be created from a given list of files"
     parameters (
       queryParam[Boolean]("append")
         .description("if true, we append the items. if false, we replace"),

--- a/api/src/main/scala/com/pennsieve/api/WebhooksController.scala
+++ b/api/src/main/scala/com/pennsieve/api/WebhooksController.scala
@@ -279,9 +279,11 @@ class WebhooksController(
 
         token = integrationUserToken.headOption
 
+        // Remove Integration API Key/Secret
         _ <- token match {
           case Some(token) =>
-            secureContainer.tokenManager
+            // Use insecure container as the actor is not the owner of the token
+            insecureContainer.tokenManager
               .delete(token, cognitoClient = cognitoClient)
               .coreErrorToActionResult()
           case None =>
@@ -289,14 +291,6 @@ class WebhooksController(
               .rightT[Future, CoreError](())
               .coreErrorToActionResult()
         }
-
-//        _ <- if userToken {
-//          _ <- secureContainer.tokenManager
-//            .delete(userToken.get, cognitoClient = cognitoClient)
-//            .coreErrorToActionResult()
-//        }
-
-        // Remove Integration API Key/Secret
 
         // Remove Integration User from Datasets
         _ <- secureContainer.datasetManager

--- a/api/src/test/scala/com/pennsieve/helpers/DataSetTestMixin.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/DataSetTestMixin.scala
@@ -335,13 +335,15 @@ trait DataSetTestMixin {
       .await
       .value
 
-    container.tokenManager
+    insecureContainer.tokenManager
       .create(
         name = "Integration-user",
         user = integrationUser,
         organization = secureContainer.organization,
         cognitoClient = mockCognito
       )
+      .await
+      .value
 
     container.webhookManager
       .create(

--- a/core/src/main/scala/com/pennsieve/managers/TokenManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/TokenManager.scala
@@ -98,6 +98,14 @@ class TokenManager(db: Database) {
     db.run(TokensMapper.getByCognitoId(cognitoId))
       .whenNone[CoreError](NotFound(s"Token by Cognito ID ($cognitoId)"))
 
+  def getByUserId(
+    userId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Token] =
+    db.run(TokensMapper.getByUser(userId))
+      .whenNone[CoreError](NotFound(s"Token by User ID ($userId)"))
+
   def update(
     token: Token
   )(implicit
@@ -201,4 +209,5 @@ class SecureTokenManager(actor: User, db: Database) extends TokenManager(db) {
       result <- super.delete(token, cognitoClient)
     } yield result
   }
+
 }


### PR DESCRIPTION
## Changes Proposed
Removing API Token using insecure container to prevent checking that actor is the same as user

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
