### PR TITLE
add logging to coreErrorToActionResult()

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/AccountController.scala
+++ b/api/src/main/scala/com/pennsieve/api/AccountController.scala
@@ -42,6 +42,7 @@ import org.scalatra._
 import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.swagger.SwaggerSupportSyntax.OperationBuilder
 import org.scalatra.swagger._
+import com.typesafe.scalalogging.{ LazyLogging, Logger }
 
 import javax.servlet.http.HttpServletRequest
 import scala.concurrent.{ ExecutionContext, Future }
@@ -79,11 +80,13 @@ class AccountController(
     with JacksonJsonSupport
     with ParamsSupport
     with PennsieveSwaggerSupport
-    with FutureSupport {
+    with FutureSupport
+    with LazyLogging {
 
   override val swaggerTag = "Account"
 
   protected implicit def executor: ExecutionContext = asyncExecutor
+  override protected implicit lazy val logger: Logger = logger
 
   protected implicit val jsonFormats
     : Formats = DefaultFormats ++ ModelSerializers.serializers

--- a/api/src/main/scala/com/pennsieve/api/AccountController.scala
+++ b/api/src/main/scala/com/pennsieve/api/AccountController.scala
@@ -86,7 +86,7 @@ class AccountController(
   override val swaggerTag = "Account"
 
   protected implicit def executor: ExecutionContext = asyncExecutor
-  override protected implicit lazy val logger: Logger = logger
+  override implicit lazy val logger: Logger = Logger("com.pennsieve")
 
   protected implicit val jsonFormats
     : Formats = DefaultFormats ++ ModelSerializers.serializers

--- a/api/src/main/scala/com/pennsieve/api/AuthenticatedController.scala
+++ b/api/src/main/scala/com/pennsieve/api/AuthenticatedController.scala
@@ -53,7 +53,7 @@ import com.pennsieve.helpers.{
 import com.pennsieve.models._
 import com.pennsieve.traits.PostgresProfile.api._
 import com.pennsieve.web.Settings
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.{ LazyLogging, Logger }
 import enumeratum.Json4s
 import javax.servlet.http.HttpServletRequest
 import org.json4s._
@@ -130,6 +130,7 @@ trait AuthenticatedController
   implicit val swagger: Swagger
 
   implicit val ec: ExecutionContext = executor
+  override implicit lazy val logger: Logger = logger
 
   protected implicit def jsonFormats: Formats =
     DefaultFormats ++ ModelSerializers.serializers

--- a/api/src/main/scala/com/pennsieve/api/AuthenticatedController.scala
+++ b/api/src/main/scala/com/pennsieve/api/AuthenticatedController.scala
@@ -130,7 +130,7 @@ trait AuthenticatedController
   implicit val swagger: Swagger
 
   implicit val ec: ExecutionContext = executor
-  override implicit lazy val logger: Logger = logger
+  override implicit lazy val logger: Logger = Logger("com.pennsieve")
 
   protected implicit def jsonFormats: Formats =
     DefaultFormats ++ ModelSerializers.serializers

--- a/api/src/main/scala/com/pennsieve/api/HealthController.scala
+++ b/api/src/main/scala/com/pennsieve/api/HealthController.scala
@@ -50,7 +50,7 @@ class HealthController(
     with LazyLogging {
 
   override protected implicit def executor: ExecutionContext = asyncExecutor
-  override protected implicit lazy val logger: Logger = logger
+  override implicit lazy val logger: Logger = Logger("com.pennsieve")
 
   protected val applicationDescription: String = "Core API"
 

--- a/api/src/main/scala/com/pennsieve/api/HealthController.scala
+++ b/api/src/main/scala/com/pennsieve/api/HealthController.scala
@@ -37,6 +37,7 @@ import com.pennsieve.traits.PostgresProfile.api._
 import com.pennsieve.core.utilities.FutureEitherHelpers.implicits._
 
 import scala.concurrent.{ ExecutionContext, Future }
+import com.typesafe.scalalogging.{ LazyLogging, Logger }
 
 class HealthController(
   insecureContainer: InsecureAPIContainer,
@@ -45,9 +46,11 @@ class HealthController(
   override val swagger: Swagger
 ) extends ScalatraServlet
     with PennsieveSwaggerSupport
-    with FutureSupport {
+    with FutureSupport
+    with LazyLogging {
 
   override protected implicit def executor: ExecutionContext = asyncExecutor
+  override protected implicit lazy val logger: Logger = logger
 
   protected val applicationDescription: String = "Core API"
 

--- a/api/src/main/scala/com/pennsieve/helpers/either/EitherTErrorHandler.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/either/EitherTErrorHandler.scala
@@ -39,6 +39,7 @@ import com.pennsieve.domain.{
 import enumeratum.{ CirceEnum, Enum, EnumEntry }
 import org.scalatra._
 import com.pennsieve.web.Settings
+import com.typesafe.scalalogging.{ LazyLogging, Logger }
 
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
@@ -218,7 +219,8 @@ object EitherTErrorHandler {
 
       def coreErrorToActionResult(
       )(implicit
-        ec: ExecutionContext
+        ec: ExecutionContext,
+        logger: Logger
       ): EitherT[Future, ActionResult, A] = {
         item.leftMap {
           case missingDataUserAgreement: MissingDataUseAgreement.type =>
@@ -291,6 +293,8 @@ object EitherTErrorHandler {
               false
             ).toActionResult()
           case error =>
+            logger.error(error.getMessage)
+            logger.error(error.stackTraceToString)
             ErrorResponse(
               ErrorResponseType.InternalServerError,
               error,


### PR DESCRIPTION


## Changes Proposed

add logging to EitherTErrorHandler.coreErrorToActionResult() in the case where item.leftMap is not matched, and produces a "500: internal server error"

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
