### PR TITLE
Data Canvas tables

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -3547,10 +3547,10 @@ class DataSetsController(
             .get(grantPreviewAccessRequest.userId)
             .coreErrorToActionResult
 
-        /*  _ <- secureContainer.datasetManager
+          /*  _ <- secureContainer.datasetManager
             .canShareWithUser(user)
             .coreErrorToActionResult
-        */
+           */
           _ <- secureContainer.datasetPreviewManager
             .grantAccess(dataset, user)
             .coreErrorToActionResult

--- a/discover-publish/src/main/scala/com/pennsieve/publish/CopyS3ObjectsFlow.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/CopyS3ObjectsFlow.scala
@@ -19,7 +19,7 @@ package com.pennsieve.publish
 import akka.NotUsed
 import akka.pattern.retry
 import akka.actor.ActorSystem
-import akka.stream.alpakka.s3.{MetaHeaders, S3Headers}
+import akka.stream.alpakka.s3.{ MetaHeaders, S3Headers }
 import akka.stream.scaladsl.Flow
 import akka.stream.alpakka.s3.scaladsl._
 import cats.data._
@@ -27,9 +27,9 @@ import cats.implicits._
 import com.pennsieve.publish.models.CopyAction
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 /**
   * Copy objects in S3 from one bucket to another
@@ -69,8 +69,8 @@ object CopyS3ObjectsFlow extends LazyLogging {
         targetKey = copyAction.copyToKey,
         chunkSize = container.s3CopyChunkSize,
         chunkingParallelism = container.s3CopyChunkParallelism,
-        s3Headers = S3Headers().
-          withCustomHeaders(Map("x-amz-request-payer" -> "requester"))
+        s3Headers = S3Headers()
+          .withCustomHeaders(Map("x-amz-request-payer" -> "requester"))
       )
       .mapMaterializedValue(_.map(_ => copyAction))
       .run()

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20220223092129__add_datacanvas_tables.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20220223092129__add_datacanvas_tables.sql
@@ -4,6 +4,7 @@ CREATE TABLE datacanvases (
     description VARCHAR(255),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    node_id VARCHAR(255) UNIQUE NOT NULL,
     permission_bit INTEGER NOT NULL DEFAULT 0,
     role VARCHAR(50),
     status_id INTEGER NOT NULL references dataset_status(id) ON DELETE RESTRICT

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20220223092129__add_datacanvas_tables.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20220223092129__add_datacanvas_tables.sql
@@ -1,0 +1,67 @@
+CREATE TABLE datacanvases (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description VARCHAR(255),
+	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    permission_bit INTEGER NOT NULL DEFAULT 0,
+    role VARCHAR(50),
+    status_id INTEGER NOT NULL references dataset_status(id) ON DELETE RESTRICT
+);
+
+CREATE INDEX datacanvases_status_id_idx
+    ON datacanvases(status_id);
+	
+CREATE TRIGGER datacanvases_update_updated_at BEFORE UPDATE ON datacanvases FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+
+CREATE TABLE datacanvas_package(
+    datacanvas_id INTEGER NOT NULL references datacanvases(id) ON DELETE CASCADE,
+    organization_id INTEGER NOT NULL references pennsieve.organizations(id) ON DELETE CASCADE,
+    package_id INTEGER NOT NULL,
+    dataset_id INTEGER NOT NULL,
+    PRIMARY KEY (datacanvas_id, organization_id, package_id)
+);
+
+CREATE INDEX datacanvas_package_datacanvas_id_idx
+    ON datacanvas_package(datacanvas_id);
+
+CREATE INDEX IF NOT EXISTS datacanvas_package_organization_id_idx
+    ON datacanvas_package(organization_id);
+
+CREATE TABLE datacanvas_user(
+    datacanvas_id INTEGER NOT NULL REFERENCES datacanvases(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES pennsieve.users(id) ON DELETE CASCADE,
+    permission_bit INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    role VARCHAR(50),
+    PRIMARY KEY (datacanvas_id, user_id)
+);
+
+CREATE INDEX datacanvas_user_datacanvas_id_idx
+    ON datacanvas_user(datacanvas_id);
+
+CREATE INDEX IF NOT EXISTS datacanvas_user_user_id_idx
+    ON datacanvas_user(user_id);
+	
+CREATE TRIGGER datacanvas_user_update_updated_at BEFORE UPDATE ON datacanvas_user FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+CREATE TABLE datacanvas_team (
+    datacanvas_id INTEGER NOT NULL references datacanvases(id) ON DELETE CASCADE,
+    team_id INTEGER NOT NULL references pennsieve.teams(id) ON DELETE CASCADE,
+    permission_bit INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    role VARCHAR(50),
+    PRIMARY KEY (datacanvas_id, team_id)
+);
+
+CREATE INDEX datacanvas_team_datacanvas_id_idx
+    ON datacanvas_team(datacanvas_id);
+
+CREATE INDEX datacanvas_team_team_id_idx
+    ON datacanvas_team(team_id);
+
+CREATE TRIGGER datacanvas_team_update_updated_at BEFORE UPDATE ON datacanvas_team FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20220223092129__add_datacanvas_tables.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20220223092129__add_datacanvas_tables.sql
@@ -2,8 +2,8 @@ CREATE TABLE datacanvases (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description VARCHAR(255),
-	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     permission_bit INTEGER NOT NULL DEFAULT 0,
     role VARCHAR(50),
     status_id INTEGER NOT NULL references dataset_status(id) ON DELETE RESTRICT


### PR DESCRIPTION
## Changes Proposed
Adds a migration script for the initial Data Canvas tables:

- `datacanvases` for the data canvases themselves,
- `datacanvas_package`: the join table to indicate which packages belong to a given data canvas,
- `datacanvas_user`: the join table to indicate individual users' permissions on a given data canvas, and
- `datacanvas_team`: join table for teams' permissions on  a given data canvas.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
