### PR TITLE
Delete all files

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -9120,7 +9120,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       .logEvent(
         dataset,
         ChangelogEventDetail.CreatePackage(233, None, None, None),
-        ZonedDateTime.now().minusDays(2).minusHours(1)
+        ZonedDateTime.now().minusDays(2).minusMinutes(1)
       )
       .await
       .right

--- a/jobs/src/main/scala/com/pennsieve/jobs/types/DeleteJob.scala
+++ b/jobs/src/main/scala/com/pennsieve/jobs/types/DeleteJob.scala
@@ -348,7 +348,7 @@ class DeleteJob(
         InvalidChildDeleteResult(child.nodeId)
       }
 
-  val allFilesQuery = new TableQuery(new AllFilesView(_))
+//  val allFilesQuery = new TableQuery(new AllFilesView(_))
 
   def deletePackageFiles(
     filesTable: FilesMapper
@@ -361,20 +361,20 @@ class DeleteJob(
       .mapConcat(identity)
       // if any files exist with the same s3 bucket/path do nothing
       // else delete s3 assets
-      .mapAsync(1) { file =>
-        val query = allFilesQuery
-          .filter(t => t.s3bucket === file.s3Bucket && t.s3key === file.s3Key)
-          .filter(
-            t =>
-              t.id =!= file.id && t.packageId =!= file.packageId && t.organizationId =!= filesTable.organization.id
-          )
-          .exists
-        db.run(query.result)
-          .map(keyExists => (keyExists, file))
-      }
-      .filterNot(_._1)
+//      .mapAsync(1) { file =>
+//        val query = allFilesQuery
+//          .filter(t => t.s3bucket === file.s3Bucket && t.s3key === file.s3Key)
+//          .filter(
+//            t =>
+//              t.id =!= file.id && t.packageId =!= file.packageId && t.organizationId =!= filesTable.organization.id
+//          )
+//          .exists
+//        db.run(query.result)
+//          .map(keyExists => (keyExists, file))
+//      }
+//      .filterNot(_._1)
       .flatMapConcat {
-        case (_, file: File) =>
+        case (file: File) =>
           Source.single(file).via(deleteFileS3Assets)
       }
 


### PR DESCRIPTION
## Changes Proposed
* Remove check in delete-packages endpoint where we check across all other organizations and datasets if an s3 file is referenced by other packages before deleting. We do not support multiple references and this check is very expensive in terms of sql. and is causing db to max out to 100% when deleting a dataset.
