### PR TITLE
API: changes to support merging user accounts

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/BaseApiTest.scala
+++ b/api/src/test/scala/com/pennsieve/api/BaseApiTest.scala
@@ -300,7 +300,10 @@ trait ApiSuite
     0,
     false,
     false,
-    None
+    None,
+    true,
+    None,
+    Some(CognitoId.UserPoolId(UUID.randomUUID()))
   )
   val colleague = User(
     NodeCodes.generateId(NodeCodes.userCode),
@@ -315,7 +318,10 @@ trait ApiSuite
     0,
     false,
     false,
-    None
+    None,
+    true,
+    None,
+    Some(CognitoId.UserPoolId(UUID.randomUUID()))
   )
   val other = User(
     NodeCodes.generateId(NodeCodes.userCode),
@@ -330,7 +336,10 @@ trait ApiSuite
     0,
     false,
     false,
-    None
+    None,
+    true,
+    None,
+    Some(CognitoId.UserPoolId(UUID.randomUUID()))
   )
   val integrationUserDefinition = User(
     NodeCodes.generateId(NodeCodes.userCode),

--- a/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
@@ -123,6 +123,45 @@ class TestUsersController extends BaseApiTest {
     }
   }
 
+  test("get user by my email when authenticated") {
+    get(
+      s"/email/${me.email}",
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(200)
+      body should include(loggedInUser.firstName)
+      body should include(loggedInUser.lastName)
+      body should include(loggedInUser.email)
+    }
+  }
+
+  test("get user by colleague email when authenticated") {
+    get(
+      s"/email/${colleague.email}",
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(200)
+      body should include(colleague.firstName)
+      body should include(colleague.lastName)
+      body should include(colleague.email)
+    }
+  }
+
+  test("return unauthorized when requesting user info by email with no token") {
+    get(s"/email/${me.email}") {
+      status should equal(401)
+      body should include("Unauthorized.")
+    }
+  }
+
+  test(
+    "return unauthorized when requesting user info by email with a bad token"
+  ) {
+    get(s"/email/${me.email}", headers = authorizationHeader("badtoken")) {
+      status should equal(401)
+    }
+  }
+
   test("put user info") {
     val updateReq = write(
       UpdateUserRequest(

--- a/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
@@ -197,6 +197,38 @@ class TestUsersController extends BaseApiTest {
     }
   }
 
+  test("update user email") {
+    val updatedEmail = "updated@email.com"
+    val beforeUser =
+      insecureContainer.userManager.get(loggedInUser.id).await.right.value
+    val updateReq = write(
+      UpdateUserRequest(
+        firstName = Some(beforeUser.firstName),
+        middleInitial = beforeUser.middleInitial,
+        lastName = Some(beforeUser.lastName),
+        degree = Some(beforeUser.degree.get.entryName),
+        credential = Some(beforeUser.credential),
+        organization = Some(loggedInOrganization.nodeId),
+        url = Some(beforeUser.url),
+        email = Some(updatedEmail),
+        color = Some(beforeUser.color)
+      )
+    )
+
+    putJson(
+      "/email",
+      updateReq,
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(200)
+      body should include(updatedEmail)
+
+      val updatedUser =
+        insecureContainer.userManager.get(loggedInUser.id).await.right.value
+      assert(updatedUser.email == updatedEmail)
+    }
+  }
+
   test("put user info: degree null") {
     val updateReq =
       s"""{"firstName":"newfirstname",

--- a/api/terraform/iam.tf
+++ b/api/terraform/iam.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "cognito_iam_policy_document" {
 
     actions = [
       "cognito-idp:AdminCreateUser",
+      "cognito-idp:AdminUpdateUserAttributes",
       "cognito-idp:AdminDisableProviderForUser",
       "cognito-idp:AdminDeleteUser",
       "cognito-idp:AdminDeleteUserAttributes",

--- a/core/src/main/scala/com/pennsieve/managers/UserManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/UserManager.scala
@@ -145,6 +145,24 @@ class UserManager(db: Database) {
       updatedUser <- get(user.id)
     } yield updatedUser
 
+  def updateCognitoId(
+    user: User,
+    newCognitoId: Option[CognitoId.UserPoolId]
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, User] =
+    for {
+      _ <- db
+        .run(
+          UserMapper
+            .filter(_.id === user.id)
+            .map(_.cognitoId)
+            .update(newCognitoId)
+        )
+        .toEitherT
+      updatedUser <- get(user.id)
+    } yield updatedUser
+
   def getPreferredOrganizationId(
     organizationNodeId: Option[String],
     defaultId: Option[Int]

--- a/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoClient.scala
+++ b/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoClient.scala
@@ -49,6 +49,9 @@ class MockCognito() extends CognitoClient {
   val deletedUserAttributes: mutable.ArrayBuffer[(String, List[String])] =
     mutable.ArrayBuffer.empty
 
+  val updatedUserAttributes: mutable.ArrayBuffer[(String, (String, String))] =
+    mutable.ArrayBuffer.empty
+
   def inviteUser(
     email: Email,
     suppressEmail: Boolean = false,
@@ -121,6 +124,17 @@ class MockCognito() extends CognitoClient {
     Future.successful(Unit)
   }
 
+  def updateUserAttribute(
+    username: String,
+    attributeName: String,
+    attributeValue: String
+  )(implicit
+    ec: ExecutionContext
+  ): Future[Unit] = {
+    updatedUserAttributes.append((username, (attributeName, attributeValue)))
+    Future.successful(Unit)
+  }
+
   def reset(): Unit = {
     sentDeletes.clear()
     sentInvites.clear()
@@ -130,5 +144,6 @@ class MockCognito() extends CognitoClient {
     unlinkedExternalUsers.clear()
     deletedUsers.clear()
     deletedUserAttributes.clear()
+    updatedUserAttributes.clear()
   }
 }


### PR DESCRIPTION
## Changes Proposed
New API endpoint that permits looking up a user by email address.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
