### PR TITLE
API: Orcid sign up loose ends 5

### DIFF
--- a/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
@@ -451,7 +451,7 @@ class Cognito(
   ): Future[Boolean] = {
     val request = AdminSetUserPasswordRequest
       .builder()
-      .userPoolId(cognitoConfig.tokenPool.id)
+      .userPoolId(cognitoConfig.userPool.id)
       .username(username)
       .password(password)
       .permanent(true)


### PR DESCRIPTION
## Changes Proposed

- FIX: setUserPassword on user pool (not token pool)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
