### PR TITLE
FIX: delete dataset with changelog (database constraint update)

### DIFF
--- a/migrations/src/main/resources/db/organization-schema-migrations/V20220705140299__alter_dataset_changelog_foreign_key.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20220705140299__alter_dataset_changelog_foreign_key.sql
@@ -1,0 +1,8 @@
+ALTER TABLE datasets
+    DROP CONSTRAINT datasets_changelog_id_fkey;
+
+ALTER TABLE datasets
+    ADD CONSTRAINT datasets_changelog_id_fkey
+        FOREIGN KEY (changelog_id)
+        REFERENCES dataset_assets(id)
+        ON DELETE SET NULL;


### PR DESCRIPTION
## Changes Proposed

Update the changelog foreign key constraint on the datasets table to null the changelog_id column when the corresponding dataset_assets row is deleted.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
