### PR TITLE
Add Cognito identity pool config key to api and admin

### DIFF
--- a/admin/src/main/resources/application.conf
+++ b/admin/src/main/resources/application.conf
@@ -109,5 +109,10 @@ cognito {
     app_client_id = ${?COGNITO_TOKEN_POOL_APP_CLIENT_ID}
   }
 
+  identity_pool {
+      id = "us-east-1:18445740-73e6-471b-b94c-7e7e5921d6d8"
+      id = ${?COGNITO_IDENTITY_POOL_ID}
+  }
+
   region = "us-east-1"
 }

--- a/admin/terraform/data.tf
+++ b/admin/terraform/data.tf
@@ -112,3 +112,14 @@ data "terraform_remote_state" "authentication_service" {
     region = "us-east-1"
   }
 }
+
+# Import Upload Service V2
+data "terraform_remote_state" "upload_service_v2" {
+  backend = "s3"
+
+  config = {
+    bucket = "${var.aws_account}-terraform-state"
+    key    = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/upload-service-v2/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/admin/terraform/ssm.tf
+++ b/admin/terraform/ssm.tf
@@ -170,3 +170,9 @@ resource "aws_ssm_parameter" "s3_terms_of_service_bucket" {
   type  = "String"
   value = data.terraform_remote_state.platform_infrastructure.outputs.terms_of_service_bucket_id
 }
+
+resource "aws_ssm_parameter" "identity_token_pool_id" {
+  name  = "/${var.environment_name}/${var.service_name}/cognito-identity-pool-id"
+  type  = "String"
+  value = data.terraform_remote_state.upload_service_v2.outputs.identity_pool_id
+}

--- a/api/src/main/resources/application.conf
+++ b/api/src/main/resources/application.conf
@@ -248,6 +248,11 @@ cognito {
     app_client_id = ${?COGNITO_TOKEN_POOL_APP_CLIENT_ID}
   }
 
+  identity_pool {
+      id = "us-east-1:18445740-73e6-471b-b94c-7e7e5921d6d8"
+      id = ${?COGNITO_IDENTITY_POOL_ID}
+  }
+
   region = "us-east-1"
 }
 

--- a/api/terraform/data.tf
+++ b/api/terraform/data.tf
@@ -177,7 +177,7 @@ data "terraform_remote_state" "authentication_service" {
 }
 
 # Import Upload-V2 Service
-data "terraform_remote_state" "upload_v2_service" {
+data "terraform_remote_state" "upload_service_v2" {
   backend = "s3"
 
   config = {

--- a/api/terraform/ssm.tf
+++ b/api/terraform/ssm.tf
@@ -361,3 +361,9 @@ resource "aws_ssm_parameter" "integration_sns_topic" {
   type  = "String"
   value = data.terraform_remote_state.integration_service.outputs.sns_topic_arn
 }
+
+resource "aws_ssm_parameter" "identity_token_pool_id" {
+  name  = "/${var.environment_name}/${var.service_name}/cognito-identity-pool-id"
+  type  = "String"
+  value = data.terraform_remote_state.upload_service_v2.outputs.identity_pool_id
+}


### PR DESCRIPTION
## Changes Proposed

The api server now needs access to the Cognito identity pool to start up. This PR gives api and admin access to this SSM variable and passes it into their configs.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
