### PR TITLE
Standardize on 'upload_service_v2' in terraform modules

### DIFF
--- a/api/terraform/iam.tf
+++ b/api/terraform/iam.tf
@@ -201,8 +201,8 @@ data "aws_iam_policy_document" "s3_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.uploads_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.dataset_assets_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.dataset_assets_bucket_arn}/*",
-      data.terraform_remote_state.upload_v2_service.outputs.uploads_bucket_arn,
-      "${data.terraform_remote_state.upload_v2_service.outputs.uploads_bucket_arn}/*",
+      data.terraform_remote_state.upload_service_v2.outputs.uploads_bucket_arn,
+      "${data.terraform_remote_state.upload_service_v2.outputs.uploads_bucket_arn}/*",
     ]
   }
 

--- a/discover-publish/terraform/data.tf
+++ b/discover-publish/terraform/data.tf
@@ -106,7 +106,7 @@ data "terraform_remote_state" "discover_s3clean_lambda" {
 }
 
 # Import Upload-V2 Service
-data "terraform_remote_state" "upload_v2_service" {
+data "terraform_remote_state" "upload_service_v2" {
   backend = "s3"
 
   config = {

--- a/discover-publish/terraform/iam.tf
+++ b/discover-publish/terraform/iam.tf
@@ -108,8 +108,8 @@ data "aws_iam_policy_document" "ecs_task_iam_policy_document" {
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo_bucket_arn}/*",
-      data.terraform_remote_state.upload_v2_service.outputs.uploads_bucket_arn,
-      "${data.terraform_remote_state.upload_v2_service.outputs.uploads_bucket_arn}/*",
+      data.terraform_remote_state.upload_service_v2.outputs.uploads_bucket_arn,
+      "${data.terraform_remote_state.upload_service_v2.outputs.uploads_bucket_arn}/*",
 
     ]
   }


### PR DESCRIPTION
## Changes Proposed

There was a mixture of using 'upload_service_v2' and 'upload_v2_service' in the terraform modules including some conflicts. This PR just settles on 'upload_service_v2'.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
