### PR TITLE
Datacanvas user and related operations

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataCanvasController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataCanvasController.scala
@@ -26,6 +26,7 @@ import com.pennsieve.domain.{ CoreError, PredicateError, UnauthorizedError }
 import com.pennsieve.dtos.Builders.{
   dataCanvasDTO,
   dataCanvasFolderDTO,
+  datacanvasDTOs,
   packageDTO
 }
 import com.pennsieve.dtos.{
@@ -45,7 +46,7 @@ import com.pennsieve.helpers.ResultHandlers.{
   OkResult
 }
 import com.pennsieve.helpers.either.EitherTErrorHandler.implicits._
-import com.pennsieve.models.{ DataCanvasPackage, Package }
+import com.pennsieve.models.{ DataCanvasPackage, Package, Role }
 import org.json4s.{ JNothing, JValue }
 import org.scalatra.{ ActionResult, AsyncResult, BadRequest, ScalatraServlet }
 import org.scalatra.swagger.Swagger
@@ -105,6 +106,37 @@ class DataCanvasController(
   //
   // DataCanvas operations
   //
+
+  /**
+    * GET the DataCanvases owned by the requesting user
+    */
+  get(
+    "/",
+    operation(
+      apiOperation[List[DataCanvasDTO]]("getOwnedDataCanvases")
+        summary "gets the data-canvases owner by the user"
+    )
+  ) {
+    new AsyncResult {
+      val result: EitherT[Future, ActionResult, Seq[DataCanvasDTO]] = for {
+        secureContainer <- getSecureContainer
+        userId = secureContainer.user.id
+
+        canvases <- secureContainer.dataCanvasManager
+          .getForUser(userId = userId, withRole = Role.Owner)
+          .coreErrorToActionResult
+
+        dtos <- datacanvasDTOs(canvases)(
+          asyncExecutor,
+          secureContainer,
+          system,
+          jwtConfig
+        ).coreErrorToActionResult
+
+      } yield dtos
+      override val is = result.value.map(OkResult(_))
+    }
+  }
 
   /**
     * GET a DataCanvas by its internal numeric identifier (`id`)

--- a/api/src/main/scala/com/pennsieve/api/DataCanvasController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataCanvasController.scala
@@ -28,7 +28,13 @@ import com.pennsieve.dtos.Builders.{
   dataCanvasFolderDTO,
   packageDTO
 }
-import com.pennsieve.dtos.{ DataCanvasDTO, DataCanvasFolderDTO, PackageDTO }
+import com.pennsieve.dtos.{
+  DataCanvasDTO,
+  DataCanvasFolderDTO,
+  DownloadManifestDTO,
+  DownloadRequest,
+  PackageDTO
+}
 import com.pennsieve.helpers.APIContainers.{
   InsecureAPIContainer,
   SecureContainerBuilderType
@@ -816,4 +822,36 @@ class DataCanvasController(
     }
   }
 
+  //
+  // generate download manifest
+  //
+  post(
+    "/download-manifest",
+    operation(
+      apiOperation[DownloadManifestDTO]("generateDownloadManifest")
+        summary "generate a manifest for downloading the data-canvas content"
+        parameters (bodyParam[DownloadRequest])("body")
+          .description(
+            "nodeIds: the data-canvas node id (will only process first one), fileIds: ignored"
+          )
+    )
+  ) {
+    new AsyncResult {
+      val result: EitherT[Future, ActionResult, Done /*DownloadManifestDTO*/ ] =
+        for {
+          secureContainer <- getSecureContainer
+          body <- extractOrErrorT[DownloadRequest](parsedBody)
+          nodeId = body.nodeIds.head
+
+          _ <- secureContainer.dataCanvasManager
+            .getByNodeId(nodeId)
+            .coreErrorToActionResult
+
+          // get folders & packages
+          // format result
+
+        } yield Done
+      override val is = result.value.map(OkResult)
+    }
+  }
 }

--- a/api/src/test/scala/com/pennsieve/api/TestDataCanvasController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataCanvasController.scala
@@ -58,6 +58,8 @@ class TestDataCanvasController
     super.afterEach()
   }
 
+  // TODO: write a test for assign DataCanvas owner on create
+
   /**
     * GET tests (read)
     */
@@ -90,6 +92,63 @@ class TestDataCanvasController
       headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
     ) {
       status should equal(404)
+    }
+  }
+
+  test("get a user's own data-canvases requires authentication") {
+    val canvas = createDataCanvas(
+      "get a user's own data-canvases requires authentication",
+      "get a user's own data-canvases requires authentication"
+    )
+    get("/", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
+      status should equal(200)
+    }
+  }
+
+  test("get a user's own data-canvases fails when not authenticated") {
+    val canvas = createDataCanvas(
+      "get a user's own data-canvases requires authentication",
+      "get a user's own data-canvases requires authentication"
+    )
+    get("/") {
+      status should equal(401)
+    }
+  }
+
+  test("get a user's own data-canvases returns only their data-canvases") {
+    // create a data-canvas, owner = user 1
+    postJson(
+      "/",
+      write(
+        CreateDataCanvasRequest(
+          name = "test: user 1's canvas",
+          description = "test: create a new data-canvas"
+        )
+      ),
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(201)
+    }
+    // create a data-canvas, owner = user 2
+    postJson(
+      "/",
+      write(
+        CreateDataCanvasRequest(
+          name = "test: user 2's canvas",
+          description = "test: create a new data-canvas"
+        )
+      ),
+      headers = authorizationHeader(colleagueJwt) ++ traceIdHeader()
+    ) {
+      status should equal(201)
+    }
+    // invoke the API for user 1
+    get("/", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
+      status should equal(200)
+      // only one data-canvas should be returned
+      val result: List[DataCanvasDTO] = parsedBody
+        .extract[List[DataCanvasDTO]]
+      result.length should equal(1)
     }
   }
 

--- a/core-models/src/main/scala/com/pennsieve/models/DataCanvasUser.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DataCanvasUser.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import java.time.ZonedDateTime
+
+case class DataCanvasUser(
+  datacanvasId: Int,
+  userId: Int,
+  permission: DBPermission,
+  role: Option[Role],
+  createdAt: ZonedDateTime = ZonedDateTime.now,
+  updatedAt: ZonedDateTime = ZonedDateTime.now
+)

--- a/core/src/main/scala/com/pennsieve/db/DataCanvasUserTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DataCanvasUserTable.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import java.time.ZonedDateTime
+import com.pennsieve.models._
+import com.pennsieve.traits.PostgresProfile.api._
+import scala.concurrent.ExecutionContext
+
+class DataCanvasUserTable(schema: String, tag: Tag)
+    extends Table[DataCanvasUser](tag, Some(schema), "datacanvas_user") {
+
+  def datacanvasId: Rep[Int] = column[Int]("datacanvas_id")
+  def userId: Rep[Int] = column[Int]("user_id")
+  def permission: Rep[DBPermission] = column[DBPermission]("permission_bit")
+  def role: Rep[Option[Role]] = column[Option[Role]]("role")
+  def createdAt = column[ZonedDateTime]("created_at", O.AutoInc)
+  def updatedAt = column[ZonedDateTime]("updated_at", O.AutoInc)
+
+  def pk = primaryKey("combined_pk", (datacanvasId, userId))
+
+  def * =
+    (datacanvasId, userId, permission, role, createdAt, updatedAt)
+      .mapTo[DataCanvasUser]
+}
+
+class DataCanvasUserMapper(organization: Organization)
+    extends TableQuery(new DataCanvasUserTable(organization.schemaId, _)) {
+
+  def getByUserId(
+    userId: Int
+  ): Query[DataCanvasUserTable, DataCanvasUser, Seq] =
+    this.filter(_.userId === userId)
+
+  def getByCanvasId(
+    datacanvasId: Int
+  ): Query[DataCanvasUserTable, DataCanvasUser, Seq] =
+    this.filter(_.datacanvasId === datacanvasId)
+
+  def get(
+    userId: Int,
+    datacanvasId: Int
+  ): Query[DataCanvasUserTable, DataCanvasUser, Seq] =
+    this
+      .filter(_.userId === userId)
+      .filter(_.datacanvasId === datacanvasId)
+
+  def getUsersFor(
+    datacanvasId: Int
+  ): Query[(DataCanvasUserTable, UserTable), (DataCanvasUser, User), Seq] =
+    this
+      .getByCanvasId(datacanvasId)
+      .join(UserMapper)
+      .on(_.userId === _.id)
+}

--- a/core/src/main/scala/com/pennsieve/db/DataCanvasUserTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DataCanvasUserTable.scala
@@ -66,4 +66,25 @@ class DataCanvasUserMapper(organization: Organization)
       .getByCanvasId(datacanvasId)
       .join(UserMapper)
       .on(_.userId === _.id)
+
+  def maxRoles(
+    userId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] =
+    this
+      .filter(_.userId === userId)
+      .map { row =>
+        row.datacanvasId -> row.role
+      }
+      .distinct
+      .result
+      .map { result =>
+        result
+          .groupBy(_._1)
+          .map {
+            case (resultDataCanvasId, group) =>
+              resultDataCanvasId -> group.map(_._2).max
+          }
+      }
 }

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -794,6 +794,37 @@ object Builders {
       )
   }
 
+  def datacanvasDTOs[DIContainer <: DataCanvasManagerContainer](
+    datacanvases: Seq[DataCanvas]
+  )(implicit
+    executionContext: ExecutionContext,
+    secureContainer: DIContainer,
+    system: ActorSystem,
+    jwtConfig: Jwt.Config
+  ): EitherT[Future, CoreError, List[DataCanvasDTO]] = {
+    for {
+      dtos <- datacanvases.toList
+        .traverse {
+          case datacanvas: DataCanvas =>
+            for {
+              _ <- secureContainer.dataCanvasManager.isLocked(datacanvas)
+            } yield
+              DataCanvasDTO(
+                id = datacanvas.id,
+                name = datacanvas.name,
+                description = datacanvas.description,
+                createdAt = datacanvas.createdAt,
+                updatedAt = datacanvas.updatedAt,
+                nodeId = datacanvas.nodeId,
+                permissionBit = datacanvas.permissionBit,
+                role = datacanvas.role,
+                statusId = datacanvas.statusId,
+                isPublic = datacanvas.isPublic
+              )
+        }
+    } yield dtos
+  }
+
   def dataCanvasFolderDTO[DIContainer <: DataCanvasManagerContainer](
     folder: DataCanvasFolder
   )(implicit

--- a/core/src/main/scala/com/pennsieve/managers/DataCanvasManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DataCanvasManager.scala
@@ -18,16 +18,43 @@ package com.pennsieve.managers
 
 import cats.data._
 import cats.implicits._
-import com.pennsieve.core.utilities.{FutureEitherHelpers, checkOrErrorT}
-import com.pennsieve.db.{AllDataCanvasesViewMapper, DataCanvasFolderMapper, DataCanvasMapper, DataCanvasPackageMapper, DataCanvasUserMapper, PackagesMapper}
-import com.pennsieve.domain.{CoreError, NotFound, PredicateError, ServiceError, SqlError}
-import com.pennsieve.models.{DBPermission, DataCanvas, DataCanvasFolder, DataCanvasPackage, DataCanvasUser, NodeCodes, Organization, Package, Role, User}
+import com.pennsieve.core.utilities.{ checkOrErrorT, FutureEitherHelpers }
+import com.pennsieve.db.{
+  AllDataCanvasesViewMapper,
+  DataCanvasFolderMapper,
+  DataCanvasMapper,
+  DataCanvasPackageMapper,
+  DataCanvasUserMapper,
+  PackagesMapper
+}
+import com.pennsieve.domain.{
+  CoreError,
+  NotFound,
+  PredicateError,
+  ServiceError,
+  SqlError
+}
+import com.pennsieve.models.{
+  DBPermission,
+  DataCanvas,
+  DataCanvasFolder,
+  DataCanvasPackage,
+  DataCanvasUser,
+  NodeCodes,
+  Organization,
+  Package,
+  Role,
+  User
+}
 import com.pennsieve.traits.PostgresProfile.api._
-import com.pennsieve.core.utilities.FutureEitherHelpers.implicits.{FutureEitherT, _}
+import com.pennsieve.core.utilities.FutureEitherHelpers.implicits.{
+  FutureEitherT,
+  _
+}
 import com.pennsieve.messages.BackgroundJob
 import org.postgresql.util.PSQLException
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 import slick.dbio.DBIO
 
 object DataCanvasManager {
@@ -149,6 +176,19 @@ class DataCanvasManager(
           .headOption
       )
       .whenNone(NotFound(id.toString))
+
+  def getByNodeId(
+    nodeId: String
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, DataCanvas] =
+    db.run(
+        datacanvasMapper
+          .filter(_.nodeId === nodeId)
+          .result
+          .headOption
+      )
+      .whenNone(NotFound(nodeId))
 
   def update(
     dataCanvas: DataCanvas,


### PR DESCRIPTION
## Changes Proposed
Adds the following DataCanvas-related capabilities:
- assign owner on create
- get/list only owned data-canvases

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
