### PR TITLE
Fix PR 194 docker builds 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,6 +149,7 @@ def generatePublishContainerStep(String service, String sbt, String imageTag, cr
                 case 'api':
                     (images, tag) = [[service], imageTag]
                     dockerPrefix = '+' // just need + for api since it's the only 2.13 container for now
+                    break
                 default:
                     (images, tag) = [[service], imageTag]
                     dockerPrefix = ''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,23 +134,29 @@ def generatePublishContainerStep(String service, String sbt, String imageTag, cr
 
             // Handle exceptions to standard service deploys
             // discover-publish and uploads-consumer utilize multiple containers
-            def images, tag, buildPath
+            def images, tag, buildPath, dockerPrefix
             switch(service) {
                 case 'discover-publish':
                     (images, tag) = [[service, 'discover-pgdump-postgres'], imageTag]
                     buildPath = 'discover-publish/'
+                    dockerPrefix = ''
                     break
                 case 'uploads-consumer':
                     (images, tag) = [[service, 'clamd'], imageTag]
                     buildPath = 'uploads-consumer/clamd/'
+                    dockerPrefix = ''
                     break
+                case 'api':
+                    (images, tag) = [[service], imageTag]
+                    dockerPrefix = '+' // just need + for api since it's the only 2.13 container for now
                 default:
                     (images, tag) = [[service], imageTag]
+                    dockerPrefix = ''
                     break
             }
 
             withCredentials([creds]) {
-                sh "${sbt} clean +pullRemoteCache ${service}/docker"
+                sh "${sbt} clean +pullRemoteCache ${dockerPrefix}${service}/docker"
             }
 
             for (image in images) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,7 @@ def generatePublishContainerStep(String service, String sbt, String imageTag, cr
             }
 
             withCredentials([creds]) {
-                sh "${sbt} clean pullRemoteCache ${service}/docker"
+                sh "${sbt} clean +pullRemoteCache ${service}/docker"
             }
 
             for (image in images) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.9.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 


### PR DESCRIPTION
Need to prepend `+` to `pushRemoteCache` for sbt docker jobs because PR #194 introduced a mix of 2.12 and 2.13 services.

Also need to prepend `+` to `api/docker` otherwise we get a .`war` file with some some internal dependencies compiled with 2.12.  

