### PR TITLE
Custom publish buckets for discover-publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val unwantedDependencies = Seq(
   ExclusionRule("commons-logging", "commons-logging"),
   // Drop core-models pulled in as a transitive dependency by clients
   ExclusionRule("com.pennsieve", "core-models_2.13"),
-  ExclusionRule("com.typesafe.akka",  "akka-protobuf-v3_2.13")
+  ExclusionRule("com.typesafe.akka", "akka-protobuf-v3_2.13")
 )
 
 import sbtassembly.MergeStrategy
@@ -151,7 +151,7 @@ lazy val commonSettings = Seq(
     "-language:postfixOps",
     "-language:implicitConversions",
     "-feature",
-    "-deprecation",
+    "-deprecation"
   ),
   assembly / test := {},
   libraryDependencies ++= Seq(
@@ -166,7 +166,7 @@ lazy val commonSettings = Seq(
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
     "org.postgresql" % "postgresql" % postgresVersion,
     "com.typesafe.slick" %% "slick" % slickVersion,
-    "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
+    "com.typesafe.slick" %% "slick-hikaricp" % slickVersion
   ),
   excludeDependencies ++= unwantedDependencies
 )
@@ -441,7 +441,7 @@ lazy val bfAkkaHttpSettings = Seq(
     // testing deps
     "org.scalatest" %% "scalatest" % scalatestVersion % Test,
     "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test
-  ),
+  )
 )
 
 lazy val migrationsSettings = Seq(
@@ -504,9 +504,7 @@ lazy val inviteCognitoUserSettings = Seq(
 
 lazy val etlDataCLISettings = Seq(
   name := "etl-data-cli",
-  libraryDependencies ++= Seq(
-    "com.github.scopt" %% "scopt" % "3.7.1",
-  ),
+  libraryDependencies ++= Seq("com.github.scopt" %% "scopt" % "3.7.1"),
   excludeDependencies ++= unwantedDependencies,
   docker / dockerfile := {
     val artifact: File = assembly.value
@@ -595,7 +593,7 @@ lazy val coreModelsSettings = Seq(
     "io.circe" %% "circe-parser" % circeVersion,
     "org.scalatest" %% "scalatest" % scalatestVersion % Test,
     "com.google.guava" % "guava" % "29.0-jre"
-  ),
+  )
 )
 
 lazy val bfAwsSettings = Seq(
@@ -620,7 +618,9 @@ lazy val discoverPublishSettings = Seq(
     "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
     "com.typesafe.akka" %% "akka-stream-typed" % akkaVersion,
     "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-    "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test
+    "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
+    "org.scalamock" %% "scalamock" % "5.2.0" % Test,
+    "org.mock-server" % "mockserver-client-java-no-dependencies" % "5.14.0" % Test
   ),
   excludeDependencies ++= unwantedDependencies,
   docker / dockerfile := {

--- a/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
@@ -27,8 +27,10 @@ import com.amazonaws.services.s3.model.{
   CopyObjectResult,
   CopyPartRequest,
   CopyPartResult,
+  DeleteObjectRequest,
   GeneratePresignedUrlRequest,
   GetObjectMetadataRequest,
+  GetObjectRequest,
   HeadBucketRequest,
   HeadBucketResult,
   InitiateMultipartUploadRequest,
@@ -53,6 +55,12 @@ trait S3Trait {
 
   def getObject(bucket: String, key: String): Either[Throwable, S3Object]
 
+  def getObject(
+    bucket: String,
+    key: String,
+    isRequestorPays: Boolean
+  ): Either[Throwable, S3Object]
+
   def getObjectMetadata(s3URI: AmazonS3URI): Either[Throwable, ObjectMetadata]
 
   def getObjectMetadata(
@@ -64,7 +72,14 @@ trait S3Trait {
     request: GetObjectMetadataRequest
   ): Either[Throwable, ObjectMetadata]
 
-  def deleteObject(bucket: String, key: String): Either[Throwable, Unit]
+  def deleteObject(
+    bucket: String,
+    key: String,
+    isRequestorPays: Boolean
+  ): Either[Throwable, Unit]
+
+  def deleteObject(bucket: String, key: String): Either[Throwable, Unit] =
+    deleteObject(bucket, key, false)
 
   def deleteObject(o: S3Object): Either[Throwable, Unit] =
     deleteObject(o.getBucketName, o.getKey)
@@ -231,11 +246,18 @@ trait S3Trait {
 class S3(val client: AmazonS3) extends S3Trait {
 
   def getObject(s3URI: AmazonS3URI): Either[Throwable, S3Object] =
-    Either.catchNonFatal(client.getObject(s3URI.getBucket, s3URI.getKey))
+    getObject(s3URI.getBucket, s3URI.getKey, false)
 
   def getObject(bucket: String, key: String): Either[Throwable, S3Object] =
+    getObject(bucket, key, false)
+
+  def getObject(
+    bucket: String,
+    key: String,
+    isRequestorPays: Boolean
+  ): Either[Throwable, S3Object] =
     Either.catchNonFatal {
-      client.getObject(bucket, key)
+      client.getObject(new GetObjectRequest(bucket, key, isRequestorPays))
     }
 
   def getObjectMetadata(s3URI: AmazonS3URI): Either[Throwable, ObjectMetadata] =
@@ -258,9 +280,15 @@ class S3(val client: AmazonS3) extends S3Trait {
       client.getObjectMetadata(request)
     }
 
-  def deleteObject(bucket: String, key: String): Either[Throwable, Unit] =
+  def deleteObject(
+    bucket: String,
+    key: String,
+    isRequestorPays: Boolean
+  ): Either[Throwable, Unit] =
     Either.catchNonFatal {
-      client.deleteObject(bucket, key)
+      val request =
+        new DeleteObjectRequest(bucket, key).withRequesterPays(isRequestorPays)
+      client.deleteObject(request)
     }
 
   def deleteObjectsByPrefix(

--- a/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
@@ -58,7 +58,7 @@ trait S3Trait {
   def getObject(
     bucket: String,
     key: String,
-    isRequestorPays: Boolean
+    isRequesterPays: Boolean
   ): Either[Throwable, S3Object]
 
   def getObjectMetadata(s3URI: AmazonS3URI): Either[Throwable, ObjectMetadata]
@@ -75,7 +75,7 @@ trait S3Trait {
   def deleteObject(
     bucket: String,
     key: String,
-    isRequestorPays: Boolean
+    isRequesterPays: Boolean
   ): Either[Throwable, Unit]
 
   def deleteObject(bucket: String, key: String): Either[Throwable, Unit] =
@@ -254,10 +254,10 @@ class S3(val client: AmazonS3) extends S3Trait {
   def getObject(
     bucket: String,
     key: String,
-    isRequestorPays: Boolean
+    isRequesterPays: Boolean
   ): Either[Throwable, S3Object] =
     Either.catchNonFatal {
-      client.getObject(new GetObjectRequest(bucket, key, isRequestorPays))
+      client.getObject(new GetObjectRequest(bucket, key, isRequesterPays))
     }
 
   def getObjectMetadata(s3URI: AmazonS3URI): Either[Throwable, ObjectMetadata] =
@@ -283,11 +283,11 @@ class S3(val client: AmazonS3) extends S3Trait {
   def deleteObject(
     bucket: String,
     key: String,
-    isRequestorPays: Boolean
+    isRequesterPays: Boolean
   ): Either[Throwable, Unit] =
     Either.catchNonFatal {
       val request =
-        new DeleteObjectRequest(bucket, key).withRequesterPays(isRequestorPays)
+        new DeleteObjectRequest(bucket, key).withRequesterPays(isRequesterPays)
       client.deleteObject(request)
     }
 

--- a/core/src/test/scala/com/pennsieve/test/helpers/EitherBePropertyMatchers.scala
+++ b/core/src/test/scala/com/pennsieve/test/helpers/EitherBePropertyMatchers.scala
@@ -19,13 +19,12 @@ import org.scalatest.matchers.{ BePropertyMatchResult, BePropertyMatcher }
 
 trait EitherBePropertyMatchers {
 
-  val left = new BePropertyMatcher[Either[AnyRef, AnyRef]] {
-    override def apply(e: Either[AnyRef, AnyRef]): BePropertyMatchResult =
-      BePropertyMatchResult(e.isLeft, "left")
-  }
-  val right = new BePropertyMatcher[Either[AnyRef, AnyRef]] {
-    override def apply(e: Either[AnyRef, AnyRef]): BePropertyMatchResult =
-      BePropertyMatchResult(e.isRight, "right")
-  }
+  def left[A, B]: BePropertyMatcher[Either[A, B]] =
+    (objectWithProperty: Either[A, B]) =>
+      BePropertyMatchResult(objectWithProperty.isLeft, "left")
+
+  def right[A, B]: BePropertyMatcher[Either[A, B]] =
+    (objectWithProperty: Either[A, B]) =>
+      BePropertyMatchResult(objectWithProperty.isRight, "right")
 
 }

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -196,14 +196,22 @@ object Publish extends StrictLogging {
       _ = logger.info(s"Deleting temporary file: $PUBLISH_ASSETS_FILENAME")
 
       _ <- container.s3
-        .deleteObject(container.s3Bucket, publishedAssetsKey(container))
+        .deleteObject(
+          container.s3Bucket,
+          publishedAssetsKey(container),
+          isRequestorPays = true
+        )
         .toEitherT[Future]
         .leftMap[CoreError](t => ExceptionError(new Exception(t)))
 
       _ = logger.info(s"Deleting temporary file: $GRAPH_ASSETS_FILENAME")
 
       _ <- container.s3
-        .deleteObject(container.s3Bucket, graphManifestKey(container))
+        .deleteObject(
+          container.s3Bucket,
+          graphManifestKey(container),
+          isRequestorPays = true
+        )
         .toEitherT[Future]
         .leftMap[CoreError](t => ExceptionError(new Exception(t)))
     } yield ()

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -199,7 +199,7 @@ object Publish extends StrictLogging {
         .deleteObject(
           container.s3Bucket,
           publishedAssetsKey(container),
-          isRequestorPays = true
+          isRequesterPays = true
         )
         .toEitherT[Future]
         .leftMap[CoreError](t => ExceptionError(new Exception(t)))
@@ -210,7 +210,7 @@ object Publish extends StrictLogging {
         .deleteObject(
           container.s3Bucket,
           graphManifestKey(container),
-          isRequestorPays = true
+          isRequesterPays = true
         )
         .toEitherT[Future]
         .leftMap[CoreError](t => ExceptionError(new Exception(t)))

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -19,6 +19,7 @@ package com.pennsieve.publish
 import java.time.LocalDate
 import java.util.UUID
 import akka.actor.ActorSystem
+import akka.stream.alpakka.s3.S3Headers
 import akka.stream.alpakka.s3.scaladsl.S3
 import akka.stream.scaladsl.Sink
 import cats.data._
@@ -28,6 +29,7 @@ import com.amazonaws.services.s3.model.{
   ObjectMetadata,
   PutObjectRequest
 }
+import com.pennsieve.aws.s3.S3Trait
 import com.pennsieve.core.utilities
 import com.pennsieve.core.utilities.FutureEitherHelpers.implicits._
 import com.pennsieve.domain.{
@@ -69,32 +71,26 @@ object Publish extends StrictLogging {
 
   val METADATA_FILENAME: String = "manifest.json"
 
-  private def publishedAssetsKey(container: PublishContainer): String =
+  private def assetKey(
+    containerConfig: PublishContainerConfig,
+    assetFilename: String
+  ): String =
     joinKeys(
       Seq(
-        container.publishedDatasetId.toString,
-        container.version.toString,
-        PUBLISH_ASSETS_FILENAME
+        containerConfig.publishedDatasetId.toString,
+        containerConfig.version.toString,
+        assetFilename
       )
     )
 
-  private def graphManifestKey(container: PublishContainer): String =
-    joinKeys(
-      Seq(
-        container.publishedDatasetId.toString,
-        container.version.toString,
-        GRAPH_ASSETS_FILENAME
-      )
-    )
+  private def publishedAssetsKey(config: PublishContainerConfig): String =
+    assetKey(config, PUBLISH_ASSETS_FILENAME)
 
-  private def outputKey(container: PublishContainer): String =
-    joinKeys(
-      Seq(
-        container.publishedDatasetId.toString,
-        container.version.toString,
-        OUTPUT_FILENAME
-      )
-    )
+  private def graphManifestKey(config: PublishContainerConfig): String =
+    assetKey(config, GRAPH_ASSETS_FILENAME)
+
+  private def outputKey(config: PublishContainerConfig): String =
+    assetKey(config, OUTPUT_FILENAME)
 
   /**
     * These intermediate files are generated as part of publishing. After the `finalizeDataset` step runs, they should
@@ -158,7 +154,7 @@ object Publish extends StrictLogging {
     * have to reload the Postgres snapshot just to write these files.
     */
   def finalizeDataset(
-    container: PublishContainer
+    container: PublishContainerConfig
   )(implicit
     executionContext: ExecutionContext,
     system: ActorSystem
@@ -216,7 +212,7 @@ object Publish extends StrictLogging {
     * Perform a blocking, single-part download from S3.
     */
   private def downloadFromS3[T: Decoder](
-    container: PublishContainer,
+    containerConfig: PublishContainerConfig,
     key: String
   )(implicit
     executionContext: ExecutionContext,
@@ -224,8 +220,8 @@ object Publish extends StrictLogging {
   ): EitherT[Future, CoreError, T] = {
     EitherT
       .fromEither[Future](
-        container.s3
-          .getObject(container.s3Bucket, key)
+        containerConfig.s3
+          .getObject(containerConfig.s3Bucket, key, true)
           .flatMap { obj =>
             {
               Either.catchNonFatal(
@@ -244,7 +240,7 @@ object Publish extends StrictLogging {
     * Perform a blocking, single-part upload to S3.
     */
   private def uploadToS3(
-    container: PublishContainer,
+    containerConfig: PublishContainerConfig,
     key: String,
     payload: Json
   )(implicit
@@ -261,10 +257,10 @@ object Publish extends StrictLogging {
     metadata.setContentLength(payloadBytes.length)
     EitherT
       .fromEither[Future](
-        container.s3
+        containerConfig.s3
           .putObject(
             new PutObjectRequest(
-              container.s3Bucket,
+              containerConfig.s3Bucket,
               key,
               payloadInputStream,
               metadata
@@ -502,7 +498,7 @@ object Publish extends StrictLogging {
     * Write published metadata JSON file.
     */
   def writeMetadata(
-    container: PublishContainer,
+    containerConfig: PublishContainerConfig,
     manifests: List[FileManifest]
   )(implicit
     executionContext: ExecutionContext,
@@ -518,27 +514,27 @@ object Publish extends StrictLogging {
       FileManifest(METADATA_FILENAME, METADATA_FILENAME, 0, FileType.Json)
 
     val unsizedMetadata = DatasetMetadataV4_0(
-      pennsieveDatasetId = container.publishedDatasetId,
-      version = container.version,
+      pennsieveDatasetId = containerConfig.publishedDatasetId,
+      version = containerConfig.version,
       revision = None,
-      name = container.dataset.name,
-      description = container.dataset.description.getOrElse(""),
+      name = containerConfig.dataset.name,
+      description = containerConfig.dataset.description.getOrElse(""),
       creator = PublishedContributor(
-        first_name = container.user.firstName,
-        middle_initial = container.user.middleInitial,
-        last_name = container.user.lastName,
-        degree = container.user.degree,
-        orcid = Some(container.userOrcid)
+        first_name = containerConfig.user.firstName,
+        middle_initial = containerConfig.user.middleInitial,
+        last_name = containerConfig.user.lastName,
+        degree = containerConfig.user.degree,
+        orcid = Some(containerConfig.userOrcid)
       ),
-      contributors = container.contributors,
-      sourceOrganization = container.organization.name,
-      keywords = container.dataset.tags,
+      contributors = containerConfig.contributors,
+      sourceOrganization = containerConfig.organization.name,
+      keywords = containerConfig.dataset.tags,
       datePublished = LocalDate.now(),
-      license = container.dataset.license,
-      `@id` = s"https://doi.org/${container.doi}",
+      license = containerConfig.dataset.license,
+      `@id` = s"https://doi.org/${containerConfig.doi}",
       files = (metadataManifest :: manifests).sorted,
-      collections = Some(container.collections),
-      relatedPublications = Some(container.externalPublications)
+      collections = Some(containerConfig.collections),
+      relatedPublications = Some(containerConfig.externalPublications)
     )
 
     // Compute the size of the metadata, including the number of characters
@@ -553,8 +549,8 @@ object Publish extends StrictLogging {
     )
 
     uploadToS3(
-      container,
-      joinKeys(container.s3Key, METADATA_FILENAME),
+      containerConfig,
+      joinKeys(containerConfig.s3Key, METADATA_FILENAME),
       metadata.asJson
     )
   }
@@ -579,12 +575,17 @@ object Publish extends StrictLogging {
     * under the publish key.
     */
   def computeTotalSize(
-    container: PublishContainer
+    containerConfig: PublishContainerConfig
   )(implicit
     executionContext: ExecutionContext,
     system: ActorSystem
   ): EitherT[Future, CoreError, Long] =
-    S3.listBucket(container.s3Bucket, Some(container.s3Key))
+    S3.listBucket(
+        containerConfig.s3Bucket,
+        Some(containerConfig.s3Key),
+        S3Headers()
+          .withCustomHeaders(Map("x-amz-request-payer" -> "requester"))
+      )
       .map(_.size)
       .runWith(Sink.fold(0: Long)(_ + _))
       .toEitherT[CoreError](ThrowableError)

--- a/discover-publish/src/main/scala/com/pennsieve/publish/PublishContainer.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/PublishContainer.scala
@@ -48,6 +48,29 @@ case class InsecureDBContainer(config: Config, organization: Organization)
   override val postgresUseSSL = false
 }
 
+trait PublishContainerConfig {
+  def s3: S3
+  def s3Bucket: String
+  def s3AssetBucket: String
+  def s3Key: String
+  def s3AssetKeyPrefix: String
+  def s3CopyChunkSize: Int
+  def s3CopyChunkParallelism: Int
+  def s3CopyFileParallelism: Int
+  def doi: String
+  def dataset: Dataset
+  def publishedDatasetId: Int
+  def version: Int
+  def organization: Organization
+  def user: User
+  def userOrcid: String
+  def datasetRole: Option[Role]
+  def contributors: List[PublishedContributor]
+  def collections: List[PublishedCollection]
+  def externalPublications: List[PublishedExternalPublication]
+  def datasetAssetClient: DatasetAssetClient
+}
+
 case class PublishContainer(
   config: Config,
   s3: S3,
@@ -71,6 +94,7 @@ case class PublishContainer(
   externalPublications: List[PublishedExternalPublication],
   datasetAssetClient: DatasetAssetClient
 ) extends Container
+    with PublishContainerConfig
     with OrganizationContainer
     with PackagesMapperContainer
     with DatasetManagerContainer

--- a/discover-publish/src/test/scala/com/pennsieve/publish/MockServerDockerContainer.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/MockServerDockerContainer.scala
@@ -22,6 +22,10 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 import org.mockserver.client.MockServerClient
 
+//TODO Factor out the S3/Alpakka specific stuff
+// and move this (and the relevant dependencies)
+// to the appropriate place in core/test
+// to make this available to mock any service.
 object MockServerDockerContainer {
   val port: Int = 1080
   val accessKey: String = "access-key"
@@ -29,6 +33,11 @@ object MockServerDockerContainer {
   val healthCheckPath = "/mockServer/healthCheck"
 }
 
+/**
+  * The config override means this is useful for mocking S3 for
+  * Akka's Alpkka S3 module. In that library all S3 access is down through static
+  * methods, so we cannot swap in a mocked S3 client.
+  */
 final class MockServerDockerContainerImpl
     extends DockerContainer(
       dockerImage = s"mockserver/mockserver:5.14.0",
@@ -45,8 +54,7 @@ final class MockServerDockerContainerImpl
   def mappedPort(): Int = super.mappedPort(MockServerDockerContainer.port)
   val accessKey: String = MockServerDockerContainer.accessKey
   val secretKey: String = MockServerDockerContainer.secretKey
-  def url: String = s"http://${containerIpAddress}"
-  def endpointUrl: String = s"${url}:${mappedPort()}"
+  def endpointUrl: String = s"http://${containerIpAddress}:${mappedPort()}"
 
   def apply(): GenericContainer = this
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/MockServerDockerContainer.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/MockServerDockerContainer.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.publish
+
+import com.dimafeng.testcontainers.GenericContainer
+import com.pennsieve.test.{ DockerContainer, StackedDockerContainer }
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import org.mockserver.client.MockServerClient
+
+object MockServerDockerContainer {
+  val port: Int = 1080
+  val accessKey: String = "access-key"
+  val secretKey: String = "secret-key"
+  val healthCheckPath = "/mockServer/healthCheck"
+}
+
+final class MockServerDockerContainerImpl
+    extends DockerContainer(
+      dockerImage = s"mockserver/mockserver:5.14.0",
+      exposedPorts = Seq(MockServerDockerContainer.port),
+      env = Map(
+        "MOCKSERVER_LIVENESS_HTTP_GET_PATH" -> MockServerDockerContainer.healthCheckPath
+      ),
+      waitStrategy = Some(
+        new HttpWaitStrategy()
+          .forPath(MockServerDockerContainer.healthCheckPath)
+      )
+    ) {
+
+  def mappedPort(): Int = super.mappedPort(MockServerDockerContainer.port)
+  val accessKey: String = MockServerDockerContainer.accessKey
+  val secretKey: String = MockServerDockerContainer.secretKey
+  def url: String = s"http://${containerIpAddress}"
+  def endpointUrl: String = s"${url}:${mappedPort()}"
+
+  def apply(): GenericContainer = this
+
+  override def config: Config =
+    ConfigFactory
+      .empty()
+      .withValue(
+        "alpakka.s3.endpoint-url",
+        ConfigValueFactory.fromAnyRef(endpointUrl)
+      )
+      .withValue(
+        "alpakka.s3.path-style-access",
+        ConfigValueFactory.fromAnyRef(true)
+      )
+      .withValue(
+        "alpakka.s3.aws.credentials.provider",
+        ConfigValueFactory.fromAnyRef("static")
+      )
+      .withValue(
+        "alpakka.s3.aws.credentials.access-key-id",
+        ConfigValueFactory.fromAnyRef(accessKey)
+      )
+      .withValue(
+        "alpakka.s3.aws.credentials.secret-access-key",
+        ConfigValueFactory.fromAnyRef(secretKey)
+      )
+      .withValue(
+        "alpakka.s3.aws.region.provider",
+        ConfigValueFactory.fromAnyRef("static")
+      )
+      .withValue(
+        "alpakka.s3.aws.region.default-region",
+        ConfigValueFactory.fromAnyRef("us-east-1")
+      )
+
+  def mockServerClient: MockServerClient = {
+    new MockServerClient(containerIpAddress, mappedPort())
+  }
+
+}
+
+trait MockServerDockerContainer extends StackedDockerContainer {
+  val mockServerContainer = new MockServerDockerContainerImpl
+
+  override def stackedContainers =
+    mockServerContainer :: super.stackedContainers
+}

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -67,7 +67,7 @@ import scala.concurrent.ExecutionContext
 
 /**
   * This class is testing that all S3 requests for the publish bucket
-  * are setting the requestor pays header.
+  * are setting the requester pays header.
   *
   * Publishing accesses S3 two ways: 1) using our own S3 which wraps an AmazonS3 and 2) using Akka's Alpakka library
   * For 1) we use a ScalaMock in place of a real AmazonS3 and capture the requests.
@@ -277,7 +277,7 @@ class TestPublishS3Requests
         .finalizeDataset(publishContainer)
         .await should be a right
 
-      assertAkkaRequestsAreRequestorPays(akkaListObjectsRequests)
+      assertAkkaRequestsAreRequesterPays(akkaListObjectsRequests)
       forAll(getObjectCapture.values.filter(_.getBucketName == publishBucket)) {
         _.isRequesterPays should be(true)
       }
@@ -292,7 +292,7 @@ class TestPublishS3Requests
   }
 
   "Publish.publishAssets" should {
-    "include requestor pays in all requests for publish bucket to AWS" in {
+    "include requester pays in all requests for publish bucket to AWS" in {
 
       val akkaStartMultipartRequests: Vector[HttpRequest] =
         akkaStartMultipartExpectation()
@@ -341,14 +341,14 @@ class TestPublishS3Requests
         _.isRequesterPays should be(true)
       }
 
-      assertAkkaRequestsAreRequestorPays(akkaStartMultipartRequests)
-      assertAkkaRequestsAreRequestorPays(akkaCopyPartRequests)
-      assertAkkaRequestsAreRequestorPays(akkaCompleteMultipartRequests)
+      assertAkkaRequestsAreRequesterPays(akkaStartMultipartRequests)
+      assertAkkaRequestsAreRequesterPays(akkaCopyPartRequests)
+      assertAkkaRequestsAreRequesterPays(akkaCompleteMultipartRequests)
 
     }
   }
 
-  private def assertAkkaRequestsAreRequestorPays(
+  private def assertAkkaRequestsAreRequesterPays(
     requests: Seq[RequestDefinition]
   ): Unit = forAll(retrieveMockServerRequests(requests)) {
     _.containsHeader("x-amz-request-payer", "requester") should be(true)

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.publish
+import akka.actor.ActorSystem
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{
+  DeleteObjectRequest,
+  GetObjectRequest,
+  PutObjectRequest,
+  S3Object,
+  S3ObjectInputStream
+}
+import com.amazonaws.util.StringInputStream
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.circe.syntax._
+import com.pennsieve.aws.s3.S3
+import com.pennsieve.clients.{ DatasetAssetClient, S3DatasetAssetClient }
+import com.pennsieve.models.{
+  Dataset,
+  FileManifest,
+  FileType,
+  Organization,
+  Role,
+  User
+}
+import com.pennsieve.publish.models.{ ExportedGraphResult, PublishAssetResult }
+import com.pennsieve.test.PersistantTestContainers
+import com.pennsieve.test.helpers.AwaitableImplicits.toAwaitable
+import com.pennsieve.test.helpers.EitherBePropertyMatchers
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.apache.http.client.methods.HttpRequestBase
+import org.mockserver.client.MockServerClient
+import org.mockserver.model.{ ClearType, HttpRequest, MediaType }
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.scalamock.matchers.ArgCapture.CaptureAll
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.Inspectors._
+import scala.jdk.CollectionConverters._
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext
+
+class TestPublishS3Requests
+    extends AnyWordSpec
+    with Matchers
+    with MockServerDockerContainer
+    with PersistantTestContainers
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with MockFactory
+    with ValueHelper
+    with EitherBePropertyMatchers {
+
+  val testDataset: Dataset = newDataset()
+  val testOrganization: Organization = sampleOrganization
+  val publishBucket = "publish-bucket"
+  val assetBucket = "asset-bucket"
+
+  implicit var system: ActorSystem = _
+  implicit var executionContext: ExecutionContext = _
+
+  var config: Config = _
+  var mockAmazonS3: AmazonS3 = _
+  var publishMetadata: PublishContainerConfig = _
+  var publishAssetResult: PublishAssetResult = _
+  var mockServerClient: MockServerClient = _
+
+  override def afterStart(): Unit = {
+    super.afterStart()
+
+    // alpakka-s3 v1.0 can only be configured via Typesafe config passed to the
+    // actor system, or as S3Settings that are attached to every graph
+    config = ConfigFactory
+      .empty()
+      .withFallback(mockServerContainer.config)
+      .withFallback(ConfigFactory.load())
+
+    system = ActorSystem("discover-publish", config)
+    executionContext = system.dispatcher
+
+    mockServerClient = mockServerContainer.mockServerClient
+
+  }
+
+  override def beforeEach(): Unit = {
+    mockAmazonS3 = mock[AmazonS3]
+    val testS3 = new S3(mockAmazonS3)
+
+    publishMetadata = new PublishContainerConfig {
+      def s3: S3 = testS3
+      def s3Bucket = publishBucket
+      def s3AssetBucket: String = assetBucket
+      def s3Key = "key"
+      def s3AssetKeyPrefix = "asset-key-prefix"
+      def s3CopyChunkSize = 1024
+      def s3CopyChunkParallelism = 1
+      def s3CopyFileParallelism = 1
+      def doi = "doi"
+      def dataset: Dataset = testDataset
+      def publishedDatasetId = 100
+      def version = 10
+      def organization: Organization = testOrganization
+      def user: User = newUser()
+      def userOrcid = "user-orcid"
+      def datasetRole: Option[Role] = Some(Role.Owner)
+      def contributors = List(contributor)
+      def collections = List(collection)
+      def externalPublications = List(externalPublication)
+      def datasetAssetClient: DatasetAssetClient =
+        new S3DatasetAssetClient(testS3, assetBucket)
+    }
+
+    publishAssetResult = PublishAssetResult(
+      externalIdToPackagePath = Map.empty,
+      packageManifests = Nil,
+      bannerKey = Publish.BANNER_FILENAME,
+      bannerManifest = FileManifest(
+        Publish.BANNER_FILENAME,
+        "a/b",
+        0,
+        FileType.PNG,
+        None,
+        Some(UUID.randomUUID)
+      ),
+      readmeKey = Publish.README_FILENAME,
+      readmeManifest = FileManifest(
+        Publish.README_FILENAME,
+        "a/b",
+        0,
+        FileType.Markdown,
+        None,
+        Some(UUID.randomUUID)
+      ),
+      changelogKey = "changelog.md",
+      changelogManifest = FileManifest(
+        "changelog.md",
+        "a/b",
+        0,
+        FileType.Markdown,
+        None,
+        Some(UUID.randomUUID)
+      )
+    )
+
+  }
+
+  override def afterEach(): Unit = {
+    mockServerClient.clear(request(), ClearType.LOG)
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  private def mockS3Object(content: String): S3Object = {
+    val s3Object = mock[S3Object]
+    (s3Object.getObjectContent _)
+      .expects()
+      .returns(
+        new S3ObjectInputStream(
+          new StringInputStream(content),
+          mock[HttpRequestBase]: @scala.annotation.nowarn //HttpRequestBase is pulling in something deprecated
+        )
+      )
+    s3Object
+  }
+
+  "finalizeDataset" should {
+    "include requester pays on all AWS S3 requests" in {
+
+      mockServerClient
+        .when(
+          request()
+            .withMethod("GET")
+            .withPath(s"/${publishBucket}")
+        )
+        .respond(
+          response()
+            .withStatusCode(200)
+            .withContentType(MediaType.APPLICATION_XML)
+            .withBody("""<?xml version="1.0" encoding="UTF-8"?>
+                |<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                |    <Name>bucket</Name>
+                |    <Prefix/>
+                |    <KeyCount>205</KeyCount>
+                |    <MaxKeys>1000</MaxKeys>
+                |    <IsTruncated>false</IsTruncated>
+                |    <Contents>
+                |        <Key>my-image.jpg</Key>
+                |        <LastModified>2009-10-12T17:50:30.000Z</LastModified>
+                |        <ETag>"fba9dede5f27731c9771645a39863328"</ETag>
+                |        <Size>434234</Size>
+                |        <StorageClass>STANDARD</StorageClass>
+                |    </Contents>
+                |</ListBucketResult>""".stripMargin)
+        )
+
+      val publishAssetResultObject =
+        mockS3Object(publishAssetResult.asJson.toString)
+
+      val exportedGraphResultObject =
+        mockS3Object(ExportedGraphResult(Nil).asJson.toString)
+
+      val getObjectCapture = CaptureAll[GetObjectRequest]()
+      val putObjectCapture = CaptureAll[PutObjectRequest]()
+      val deleteObjectCapture = CaptureAll[DeleteObjectRequest]()
+
+      (mockAmazonS3
+        .getObject(_: GetObjectRequest))
+        .expects(capture(getObjectCapture))
+        .twice()
+        .onCall { r: GetObjectRequest =>
+          if (r.getKey.endsWith(Publish.PUBLISH_ASSETS_FILENAME)) {
+            publishAssetResultObject
+          } else if (r.getKey.endsWith(Publish.GRAPH_ASSETS_FILENAME)) {
+            exportedGraphResultObject
+          } else fail(s"Unexpected get object key: ${r.getKey}")
+        }
+
+      (mockAmazonS3.putObject(_: PutObjectRequest)).expects(*).twice()
+
+      (mockAmazonS3.deleteObject(_: DeleteObjectRequest)).expects(*).twice()
+
+      Publish
+        .finalizeDataset(publishMetadata)
+        .await should be a right
+
+      val akkaRequests: Seq[HttpRequest] =
+        mockServerClient.retrieveRecordedRequests(request()).toSeq
+
+      forAll(akkaRequests) {
+        _.containsHeader("x-amz-request-payer", "requester") should be(true)
+      }
+      forAll(getObjectCapture.values) { _.isRequesterPays should be(true) }
+      forAll(putObjectCapture.values) { _.isRequesterPays should be(true) }
+      forAll(deleteObjectCapture.values) { _.isRequesterPays should be(true) }
+
+    }
+  }
+
+}

--- a/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
@@ -15,9 +15,13 @@
  */
 
 package com.pennsieve.publish
+import com.pennsieve.aws.s3.S3
+import com.pennsieve.managers.DatasetStatusManager
 import com.pennsieve.models.{
   Dataset,
+  DatasetAsset,
   DatasetState,
+  DatasetStatus,
   Doi,
   NodeCodes,
   Organization,
@@ -27,10 +31,16 @@ import com.pennsieve.models.{
   RelationshipType,
   User
 }
+import com.pennsieve.test.helpers.AwaitableImplicits.toAwaitable
+import com.pennsieve.traits.PostgresProfile.api._
+import org.scalatest.Assertion
+import org.scalatest.EitherValues._
+import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.ExecutionContext
 import scala.util.Random
 
-trait ValueHelper {
+trait ValueHelper extends Matchers {
 
   val sampleOrganization: Organization =
     Organization("N:organization:32352", "Test org", "test-org", id = 5)
@@ -80,6 +90,147 @@ trait ValueHelper {
       description = description,
       statusId = statusId
     )
+  }
+
+  def createUser(
+    databaseContainer: InsecureDatabaseContainer,
+    email: String = s"test+${generateRandomString()}@pennsieve.org",
+    isSuperAdmin: Boolean = false
+  )(implicit
+    executionContext: ExecutionContext
+  ): User =
+    databaseContainer.userManager
+      .create(newUser(email = email, isSuperAdmin = isSuperAdmin))
+      .await
+      .value
+
+  def createDatasetStatus(
+    databaseContainer: InsecureDatabaseContainer,
+    displayName: String = generateRandomString()
+  )(implicit
+    executionContext: ExecutionContext
+  ): DatasetStatus =
+    new DatasetStatusManager(
+      databaseContainer.db,
+      databaseContainer.organization
+    ).create(displayName).await.value
+
+  def createDataset(
+    databaseContainer: InsecureDatabaseContainer,
+    name: String = generateRandomString(),
+    description: Option[String] = Some("description")
+  )(implicit
+    executionContext: ExecutionContext
+  ): Dataset = {
+    val datasetsMapper = databaseContainer.datasetsMapper
+
+    val status = createDatasetStatus(databaseContainer)
+    databaseContainer.db
+      .run(
+        (datasetsMapper returning datasetsMapper) += newDataset(
+          name = name,
+          statusId = status.id,
+          description
+        )
+      )
+      .await
+  }
+
+  // Generate random content
+  def createS3File(
+    s3: S3,
+    s3Bucket: String,
+    s3Key: String,
+    content: String = generateRandomString()
+  ): Assertion =
+    s3.putObject(s3Bucket, s3Key, content).isRight shouldBe true
+
+  def createAsset(
+    databaseContainer: InsecureDatabaseContainer,
+    dataset: Dataset,
+    name: String,
+    assetBucket: String,
+    content: String = generateRandomString(),
+    s3: Option[S3] = None
+  )(implicit
+    executionContext: ExecutionContext
+  ): DatasetAsset = {
+    val asset: DatasetAsset = databaseContainer.db
+      .run(
+        databaseContainer.datasetAssetsManager
+          .createQuery(name, dataset, assetBucket)
+      )
+      .await
+
+    s3.foreach(createS3File(_, asset.s3Bucket, asset.s3Key, content))
+    asset
+  }
+
+  def addBannerAndReadme(
+    databaseContainer: InsecureDatabaseContainer,
+    dataset: Dataset,
+    assetBucket: String,
+    s3: Option[S3] = None
+  )(implicit
+    executionContext: ExecutionContext
+  ): Dataset = {
+    val banner =
+      createAsset(
+        databaseContainer = databaseContainer,
+        dataset = dataset,
+        name = "some-image-with-any-name.jpg",
+        assetBucket = assetBucket,
+        content = "banner-data",
+        s3 = s3
+      )
+    val readme =
+      createAsset(
+        databaseContainer,
+        dataset,
+        name = Publish.README_FILENAME,
+        assetBucket = assetBucket,
+        content = "readme-data",
+        s3 = s3
+      )
+    val changelog =
+      createAsset(
+        databaseContainer,
+        dataset,
+        name = Publish.CHANGELOG_FILENAME,
+        assetBucket = assetBucket,
+        content = "changelog-data",
+        s3 = s3
+      )
+
+    val updatedDataset =
+      dataset.copy(
+        bannerId = Some(banner.id),
+        readmeId = Some(readme.id),
+        changelogId = Some(changelog.id)
+      )
+
+    databaseContainer.db
+      .run(
+        databaseContainer.datasetsMapper
+          .filter(_.id === dataset.id)
+          .update(updatedDataset)
+      )
+      .await
+
+    updatedDataset
+  }
+
+  def createDatasetWithAssets(
+    databaseContainer: InsecureDatabaseContainer,
+    name: String = generateRandomString(),
+    bucket: String,
+    description: Option[String] = Some("description"),
+    s3: Option[S3] = None
+  )(implicit
+    executionContext: ExecutionContext
+  ): Dataset = {
+    val d = createDataset(databaseContainer, name, description)
+    addBannerAndReadme(databaseContainer, d, bucket, s3)
   }
 
 }

--- a/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/ValueHelper.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.publish
+import com.pennsieve.models.{
+  Dataset,
+  DatasetState,
+  Doi,
+  NodeCodes,
+  Organization,
+  PublishedCollection,
+  PublishedContributor,
+  PublishedExternalPublication,
+  RelationshipType,
+  User
+}
+
+import scala.util.Random
+
+trait ValueHelper {
+
+  val sampleOrganization: Organization =
+    Organization("N:organization:32352", "Test org", "test-org", id = 5)
+  val contributor: PublishedContributor =
+    PublishedContributor(
+      first_name = "John",
+      middle_initial = Some("G"),
+      last_name = "Malkovich",
+      degree = None,
+      orcid = Some("0000-0003-8769-1234")
+    )
+  val collection: PublishedCollection = PublishedCollection(
+    "My awesome collection"
+  )
+  val externalPublication: PublishedExternalPublication =
+    PublishedExternalPublication(
+      Doi("10.26275/t6j6-77pu"),
+      Some(RelationshipType.References)
+    )
+  def generateRandomString(size: Int = 10): String =
+    Random.alphanumeric.filter(_.isLetter).take(size).mkString
+
+  def newUser(
+    email: String = s"test+${generateRandomString()}@pennsieve.org",
+    isSuperAdmin: Boolean = false
+  ): User =
+    User(
+      nodeId = NodeCodes.generateId(NodeCodes.userCode),
+      email = email,
+      firstName = "Test",
+      middleInitial = None,
+      lastName = "User",
+      degree = None,
+      isSuperAdmin = isSuperAdmin
+    )
+
+  def newDataset(
+    name: String = generateRandomString(),
+    statusId: Int = 1,
+    description: Option[String] = Some("description")
+  ): Dataset = {
+
+    Dataset(
+      NodeCodes.generateId(NodeCodes.dataSetCode),
+      name,
+      DatasetState.READY,
+      description = description,
+      statusId = statusId
+    )
+  }
+
+}


### PR DESCRIPTION
## Changes Proposed

This PR completes the work involved with getting discover-publish to be able to handle custom publish buckets that are set as requestor pays.

All calls that discover-publish makes to S3 that involve the publish bucket now include the requestor pays header. This is verified by a new test class.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
