### PR TITLE
fix: Check whether a User has a linked Cognito Identity before trying…

### DIFF
--- a/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoClient.scala
+++ b/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoClient.scala
@@ -103,6 +103,13 @@ class MockCognito() extends CognitoClient {
     Future.successful(())
   }
 
+  def hasExternalUserLink(
+    username: String,
+    providerName: String
+  )(implicit
+    ec: ExecutionContext
+  ): Future[Boolean] = Future.successful(true)
+
   def unlinkExternalUser(
     providerName: String,
     attributeName: String,


### PR DESCRIPTION
… to Unlink

## Changes Proposed

- check whether the Cognito user has a linked identity
- if yes, then remove it and delete the associated Cognito user; if no, then skip those steps

[ClickUp ticket](https://app.clickup.com/t/2fte9rk)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
