### PR TITLE
AWS.deleteObject workaround

### DIFF
--- a/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
@@ -304,7 +304,7 @@ class S3(val client: AmazonS3) extends S3Trait {
     isRequesterPays: Boolean = false
   ): Either[Throwable, Unit] =
     Either.catchNonFatal {
-      require(keys.length <= 1000)
+      require(keys.length <= 1000, s"number of keys must be <= 1000: ${keys.length}")
       val request = new DeleteObjectsRequest(bucket)
         .withKeys(keys: _*)
         .withRequesterPays(isRequesterPays)

--- a/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
@@ -293,9 +293,17 @@ class S3(val client: AmazonS3) extends S3Trait {
     isRequesterPays: Boolean
   ): Either[Throwable, Unit] =
     Either.catchNonFatal {
-      val request =
-        new DeleteObjectRequest(bucket, key).withRequesterPays(isRequesterPays)
-      client.deleteObject(request)
+      if (!isRequesterPays) {
+        val request =
+          new DeleteObjectRequest(bucket, key)
+            .withRequesterPays(isRequesterPays)
+        client.deleteObject(request)
+      } else {
+        val request = new DeleteObjectsRequest(bucket)
+          .withKeys(key)
+          .withRequesterPays(isRequesterPays)
+        client.deleteObjects(request)
+      }
     }
 
   def deleteObjectsByKeys(
@@ -304,7 +312,10 @@ class S3(val client: AmazonS3) extends S3Trait {
     isRequesterPays: Boolean = false
   ): Either[Throwable, Unit] =
     Either.catchNonFatal {
-      require(keys.length <= 1000, s"number of keys must be <= 1000: ${keys.length}")
+      require(
+        keys.length <= 1000,
+        s"number of keys must be <= 1000: ${keys.length}"
+      )
       val request = new DeleteObjectsRequest(bucket)
         .withKeys(keys: _*)
         .withRequesterPays(isRequesterPays)

--- a/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
@@ -294,10 +294,7 @@ class S3(val client: AmazonS3) extends S3Trait {
   ): Either[Throwable, Unit] =
     Either.catchNonFatal {
       if (!isRequesterPays) {
-        val request =
-          new DeleteObjectRequest(bucket, key)
-            .withRequesterPays(isRequesterPays)
-        client.deleteObject(request)
+        client.deleteObject(bucket, key)
       } else {
         val request = new DeleteObjectsRequest(bucket)
           .withKeys(key)

--- a/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3.scala
@@ -28,6 +28,7 @@ import com.amazonaws.services.s3.model.{
   CopyPartRequest,
   CopyPartResult,
   DeleteObjectRequest,
+  DeleteObjectsRequest,
   GeneratePresignedUrlRequest,
   GetObjectMetadataRequest,
   GetObjectRequest,
@@ -83,6 +84,12 @@ trait S3Trait {
 
   def deleteObject(o: S3Object): Either[Throwable, Unit] =
     deleteObject(o.getBucketName, o.getKey)
+
+  def deleteObjectsByKeys(
+    bucket: String,
+    keys: Seq[String],
+    isRequesterPays: Boolean = false
+  ): Either[Throwable, Unit]
 
   def copyObject(
     request: CopyObjectRequest
@@ -289,6 +296,19 @@ class S3(val client: AmazonS3) extends S3Trait {
       val request =
         new DeleteObjectRequest(bucket, key).withRequesterPays(isRequesterPays)
       client.deleteObject(request)
+    }
+
+  def deleteObjectsByKeys(
+    bucket: String,
+    keys: Seq[String],
+    isRequesterPays: Boolean = false
+  ): Either[Throwable, Unit] =
+    Either.catchNonFatal {
+      require(keys.length <= 1000)
+      val request = new DeleteObjectsRequest(bucket)
+        .withKeys(keys: _*)
+        .withRequesterPays(isRequesterPays)
+      client.deleteObjects(request)
     }
 
   def deleteObjectsByPrefix(

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -194,7 +194,7 @@ object Publish extends StrictLogging {
       )
 
       _ = logger.info(
-        s"Deleting temporary files: $PUBLISH_ASSETS_FILENAME ,$GRAPH_ASSETS_FILENAME"
+        s"Deleting temporary files: $PUBLISH_ASSETS_FILENAME, $GRAPH_ASSETS_FILENAME"
       )
 
       _ <- container.s3

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -193,27 +193,19 @@ object Publish extends StrictLogging {
         ).asJson
       )
 
-      _ = logger.info(s"Deleting temporary file: $PUBLISH_ASSETS_FILENAME")
+      _ = logger.info(
+        s"Deleting temporary files: $PUBLISH_ASSETS_FILENAME ,$GRAPH_ASSETS_FILENAME"
+      )
 
       _ <- container.s3
-        .deleteObject(
+        .deleteObjectsByKeys(
           container.s3Bucket,
-          publishedAssetsKey(container),
+          Seq(publishedAssetsKey(container), graphManifestKey(container)),
           isRequesterPays = true
         )
         .toEitherT[Future]
         .leftMap[CoreError](t => ExceptionError(new Exception(t)))
 
-      _ = logger.info(s"Deleting temporary file: $GRAPH_ASSETS_FILENAME")
-
-      _ <- container.s3
-        .deleteObject(
-          container.s3Bucket,
-          graphManifestKey(container),
-          isRequesterPays = true
-        )
-        .toEitherT[Future]
-        .leftMap[CoreError](t => ExceptionError(new Exception(t)))
     } yield ()
 
   /**

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -21,6 +21,7 @@ import com.amazonaws.services.s3.model.{
   CopyObjectRequest,
   CopyObjectResult,
   DeleteObjectRequest,
+  DeleteObjectsRequest,
   GetObjectRequest,
   ObjectMetadata,
   PutObjectRequest,
@@ -249,7 +250,7 @@ class TestPublishS3Requests
 
       val getObjectCapture = CaptureAll[GetObjectRequest]()
       val putObjectCapture = CaptureAll[PutObjectRequest]()
-      val deleteObjectCapture = CaptureAll[DeleteObjectRequest]()
+      val deleteObjectsCapture = CaptureAll[DeleteObjectsRequest]()
 
       (mockAmazonS3
         .getObject(_: GetObjectRequest))
@@ -269,9 +270,8 @@ class TestPublishS3Requests
         .twice()
 
       (mockAmazonS3
-        .deleteObject(_: DeleteObjectRequest))
-        .expects(capture(deleteObjectCapture))
-        .twice()
+        .deleteObjects(_: DeleteObjectsRequest))
+        .expects(capture(deleteObjectsCapture))
 
       Publish
         .finalizeDataset(publishContainer)
@@ -285,7 +285,7 @@ class TestPublishS3Requests
         _.isRequesterPays should be(true)
       }
       forAll(
-        deleteObjectCapture.values.filter(_.getBucketName == publishBucket)
+        deleteObjectsCapture.values.filter(_.getBucketName == publishBucket)
       ) { _.isRequesterPays should be(true) }
 
     }


### PR DESCRIPTION
## Changes Proposed

It appears that the AWS client ignores the requester pays value for deleteObject requests but does check it for deleteObjects request. So this PR switches us to deleteObjects.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
