### PR TITLE
fix: mapping Role.Guest to DBPermission

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/DBPermission.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DBPermission.scala
@@ -75,6 +75,7 @@ object DBPermission
     case Some(Role.Manager) => DBPermission.Administer
     case Some(Role.Editor) => DBPermission.Delete
     case Some(Role.Viewer) => DBPermission.Read
+    case Some(Role.Guest) => DBPermission.Guest
     case None => DBPermission.NoPermission
   }
 }


### PR DESCRIPTION
## Changes Proposed

turns out we do need the mapping from Role.Guest -> DBPermission for Guest User Invite

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
