### PR TITLE
Restrict guest from using workspace permission

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/BaseApiTest.scala
+++ b/api/src/test/scala/com/pennsieve/api/BaseApiTest.scala
@@ -47,7 +47,7 @@ import com.pennsieve.clients.{
   MockJobSchedulingServiceContainer
 }
 import com.pennsieve.core.utilities._
-import com.pennsieve.models.DBPermission.{ Administer, Delete }
+import com.pennsieve.models.DBPermission.{ Administer, Delete, Guest }
 import com.pennsieve.managers._
 import com.pennsieve.managers.DatasetManager
 import com.pennsieve.helpers._
@@ -249,6 +249,7 @@ trait ApiSuite
   var superAdmin: User = _
   var sandboxUser: User = _
   var integrationUser: User = _
+  var guestUser: User = _
 
   var pennsieve: Organization = _
   var loggedInOrganization: Organization = _
@@ -261,12 +262,10 @@ trait ApiSuite
   val requestTraceId: String = "1234-4567"
 
   var colleagueJwt: String = _
-
   var integrationJwt: String = _
-
   var externalJwt: String = _
-
   var adminJwt: String = _
+  var guestJwt: String = _
 
   var sandboxUserJwt: String = _
 
@@ -282,6 +281,7 @@ trait ApiSuite
   var personal: Package = _
 
   var secureContainer: SecureAPIContainer = _
+  var secureContainerGuest: SecureAPIContainer = _
   var secureDataSetManager: DatasetManager = _
   var sandboxUserContainer: SecureAPIContainer = _
 
@@ -356,6 +356,26 @@ trait ApiSuite
     true,
     None
   )
+
+  val guest = User(
+    NodeCodes.generateId(NodeCodes.userCode),
+    "guest@test.com",
+    "first",
+    Some("M"),
+    "guest",
+    Some(Degree.MS),
+    "cred",
+    "",
+    "http://test.com",
+    0,
+    false,
+    false,
+    None,
+    true,
+    None,
+    Some(CognitoId.UserPoolId(UUID.randomUUID()))
+  )
+
   val superAdminUser = User(
     NodeCodes.generateId(NodeCodes.userCode),
     "super3@external.com",
@@ -402,8 +422,11 @@ trait ApiSuite
     colleagueUser = userManager.create(colleague).await.value
     externalUser = userManager.create(other).await.value
     integrationUser = userManager.create(integrationUserDefinition).await.value
+    guestUser = userManager.create(guest).await.value
 
     secureContainer = secureContainerBuilder(loggedInUser, loggedInOrganization)
+    secureContainerGuest =
+      secureContainerBuilder(guestUser, loggedInOrganization)
 
     secureDataSetManager = secureContainer.datasetManager
     fileManager = secureContainer.fileManager
@@ -437,6 +460,10 @@ trait ApiSuite
       .addUser(loggedInOrganization, integrationUser, Administer)
       .await
       .value
+    organizationManager
+      .addUser(loggedInOrganization, guestUser, Guest)
+      .await
+      .value
 
     loggedInJwt = Authenticator.createUserToken(
       loggedInUser,
@@ -459,6 +486,12 @@ trait ApiSuite
     )(jwtConfig, insecureContainer.db, ec)
 
     adminJwt = Authenticator.createUserToken(superAdmin, loggedInOrganization)(
+      jwtConfig,
+      insecureContainer.db,
+      ec
+    )
+
+    guestJwt = Authenticator.createUserToken(guestUser, loggedInOrganization)(
       jwtConfig,
       insecureContainer.db,
       ec

--- a/api/src/test/scala/com/pennsieve/helpers/DataSetTestMixin.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/DataSetTestMixin.scala
@@ -83,6 +83,19 @@ trait DataSetTestMixin {
       case Right(value) => value
     }
 
+  def updateDataset(
+    dataset: Dataset,
+    container: SecureAPIContainer = secureContainer
+  )(implicit
+    ec: ExecutionContext
+  ): Dataset =
+    container.datasetManager
+      .update(dataset)
+      .await match {
+      case Left(error) => throw error
+      case Right(value) => value
+    }
+
   def createDataUseAgreement(
     name: String,
     body: String

--- a/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
@@ -226,6 +226,8 @@ trait SecureCoreContainer
   implicit val datasetTeamMapper: DatasetTeamMapper =
     new DatasetTeamMapper(self.organization)
 
+  // lazy val organizationUser: OrganizationUser = ???
+
   lazy val userRoles: Future[Map[Int, Option[Role]]] =
     db.run(datasetsMapper.maxRoles(user.id))
 

--- a/core/src/main/scala/com/pennsieve/db/DatasetsTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DatasetsTable.scala
@@ -391,17 +391,23 @@ class DatasetsMapper(val organization: Organization)
       .result
 
   def datasetRoleMap(
+    guest: Boolean = false
+  )(
     implicit
     ec: ExecutionContext
-  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] =
+  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] = {
+
     this
       .map(datasetTable => datasetTable.id -> datasetTable.role)
+      .filter(_ => guest)
       .distinct
       .result
       .map(_.toMap)
+  }
 
   def maxRoles(
-    userId: Int
+    userId: Int,
+    guest: Boolean = false
   )(implicit
     datasetUserMapper: DatasetUserMapper,
     datasetTeamsMapper: DatasetTeamMapper,

--- a/core/src/main/scala/com/pennsieve/db/DatasetsTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DatasetsTable.scala
@@ -392,18 +392,15 @@ class DatasetsMapper(val organization: Organization)
 
   def datasetRoleMap(
     guest: Boolean = false
-  )(
-    implicit
+  )(implicit
     ec: ExecutionContext
-  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] = {
-
+  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] =
     this
       .map(datasetTable => datasetTable.id -> datasetTable.role)
-      .filter(_ => guest)
+      .filter(_._1 > 0 && !guest)
       .distinct
       .result
       .map(_.toMap)
-  }
 
   def maxRoles(
     userId: Int,
@@ -412,9 +409,9 @@ class DatasetsMapper(val organization: Organization)
     datasetUserMapper: DatasetUserMapper,
     datasetTeamsMapper: DatasetTeamMapper,
     ec: ExecutionContext
-  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] =
+  ): DBIOAction[Map[Int, Option[Role]], NoStream, Effect.Read] = {
     for {
-      datasetRoles <- this.datasetRoleMap
+      datasetRoles <- this.datasetRoleMap(guest)
       datasetTeamRoles <- datasetTeamsMapper.maxRoles(userId)
       datasetUserRoles <- datasetUserMapper.maxRoles(userId)
     } yield
@@ -423,6 +420,7 @@ class DatasetsMapper(val organization: Organization)
         .map {
           case (datasetId, roleGroups) => datasetId -> roleGroups.map(_._2).max
         }
+  }
 
   def datasetWithRole(
     userId: Int,


### PR DESCRIPTION
## Changes Proposed
This adds a predicate to filter out datasets that have granted permission to all workspace users when the requesting user is a guest. 

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
