### PR TITLE
expand: add isGuest to ExpandedOrganizationResponse

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/BaseApiTest.scala
+++ b/api/src/test/scala/com/pennsieve/api/BaseApiTest.scala
@@ -688,6 +688,10 @@ trait ApiSuite
   def traceIdHeader(id: String = requestTraceId): Map[String, String] =
     Map(AuditLogger.TRACE_ID_HEADER -> id)
 
+  def contentTypeHeader(
+    contentType: String = "application/json"
+  ): Map[String, String] = Map("Content-type" -> contentType)
+
   def jwtServiceAuthorizationHeader(
     organization: Organization,
     dataset: Option[Dataset] = None

--- a/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
@@ -1539,4 +1539,20 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
       )
     }
   }
+
+  test("non-guest user organization isGuest should be false") {
+    get(s"", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
+      status should equal(200)
+      body should include(loggedInOrganization.nodeId)
+      body should include("\"isGuest\":false")
+    }
+  }
+
+  test("guest user organization isGuest should be true") {
+    get(s"", headers = authorizationHeader(guestJwt) ++ traceIdHeader()) {
+      status should equal(200)
+      body should include(loggedInOrganization.nodeId)
+      body should include("\"isGuest\":true")
+    }
+  }
 }


### PR DESCRIPTION
## Changes Proposed

Add the boolean-value property isGuest to the ExpandedOrganizationResponse case class. This is set by checking whether the user's permission_bit is DBPermission.Guest. Having this value will make front-end app changes more efficient and consistent.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
