### PR TITLE
prevent guests from seeing workspace owner and admin lists

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
@@ -1558,7 +1558,6 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
 
   test("non-guest user can see organization owner and admin lists") {
     get(s"", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
-      println(s"Test >>> body: ${body}")
       status should equal(200)
       body should include(loggedInOrganization.nodeId)
       body shouldNot include("\"administrators\":[]")
@@ -1567,7 +1566,6 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
 
   test("guest user cannot see organization owner and admin list") {
     get(s"", headers = authorizationHeader(guestJwt) ++ traceIdHeader()) {
-      println(s"Test >>> body: ${body}")
       status should equal(200)
       body should include(loggedInOrganization.nodeId)
       body should include("\"owners\":[]")

--- a/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
@@ -1561,12 +1561,12 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
       println(s"Test >>> body: ${body}")
       status should equal(200)
       body should include(loggedInOrganization.nodeId)
-      body shouldNot include("\"owners\":[]")
+      body shouldNot include("\"administrators\":[]")
     }
   }
 
   test("guest user cannot see organization owner and admin list") {
-    get(s"", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
+    get(s"", headers = authorizationHeader(guestJwt) ++ traceIdHeader()) {
       println(s"Test >>> body: ${body}")
       status should equal(200)
       body should include(loggedInOrganization.nodeId)

--- a/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
@@ -1555,4 +1555,24 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
       body should include("\"isGuest\":true")
     }
   }
+
+  test("non-guest user can see organization owner and admin lists") {
+    get(s"", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
+      println(s"Test >>> body: ${body}")
+      status should equal(200)
+      body should include(loggedInOrganization.nodeId)
+      body shouldNot include("\"owners\":[]")
+    }
+  }
+
+  test("guest user cannot see organization owner and admin list") {
+    get(s"", headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()) {
+      println(s"Test >>> body: ${body}")
+      status should equal(200)
+      body should include(loggedInOrganization.nodeId)
+      body should include("\"owners\":[]")
+      body should include("\"administrators\":[]")
+    }
+  }
+
 }


### PR DESCRIPTION
## Changes Proposed

When an Organizations API request comes from a workspace guest user, do not return the list of owners and administrators.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
