### PR TITLE
Adding upload2-folder to iam role for job-service

### DIFF
--- a/jobs/terraform/data.tf
+++ b/jobs/terraform/data.tf
@@ -89,3 +89,14 @@ data "terraform_remote_state" "gateway" {
     region = "us-east-1"
   }
 }
+
+# Import Upload Service 2
+data "terraform_remote_state" "upload_service_2" {
+  backend = "s3"
+
+  config = {
+    bucket = "${var.aws_account}-terraform-state"
+    key    = "aws/${data.aws_region.current_region.name}/${var.vpc_name}/${var.environment_name}/upload-service-v2/terraform.tfstate"
+    region = "us-east-1"
+  }
+}

--- a/jobs/terraform/iam.tf
+++ b/jobs/terraform/iam.tf
@@ -68,6 +68,8 @@ data "aws_iam_policy_document" "iam_policy_document" {
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.uploads_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.uploads_bucket_arn}/*",
+      data.terraform_remote_state.upload_service_2.outputs.uploads_bucket_arn,
+      "${data.terraform_remote_state.upload_service_2.outputs.uploads_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.storage_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_storage_bucket_arn,


### PR DESCRIPTION
## Changes Proposed

Adding upload_bucket_v2 to the iam role for job-servive.
This is needed to delete s3 files before they are moved to the prod storage bucket
