### PR TITLE
fix: permit Guest to GET an organization's dataset status and members

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/OrganizationsController.scala
@@ -857,7 +857,7 @@ class OrganizationsController(
         _ <- assertNotDemoOrganization(secureContainer)
 
         organization <- secureContainer.organizationManager
-          .getByNodeId(organizationId)
+          .getByNodeId(organizationId, DBPermission.Guest)
           .coreErrorToActionResult()
 
         members <- secureContainer.organizationManager
@@ -1447,7 +1447,7 @@ class OrganizationsController(
         organizationId <- paramT[String]("organizationId")
 
         organization <- secureContainer.organizationManager
-          .getByNodeId(organizationId, DBPermission.Read)
+          .getByNodeId(organizationId, DBPermission.Guest)
           .coreErrorToActionResult()
 
         status <- new DatasetStatusManager(insecureContainer.db, organization).getAllWithUsage


### PR DESCRIPTION
## Changes Proposed

Relaxes permission on the below Organizations endpoints in order to permit Guest users to see Dataset Status, and Organization Membership. 

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
