### PR TITLE
Fix for reading some config settings

### DIFF
--- a/api/src/main/scala/com/pennsieve/helpers/BootstrapHelper.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/BootstrapHelper.scala
@@ -81,12 +81,13 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 trait ApiSQSContainer { self: Container =>
   val sqs_queue: String = config.as[String]("sqs.queue")
-  val sqs_queue_v2: String = config.as[String]("sqs.queue_v2").orElse("").toString()
+  val sqs_queue_v2: String =
+    config.as[Option[String]]("sqs.queue_v2").getOrElse("")
 }
 
 trait ApiSNSContainer { self: Container =>
   val sns_topic: String =
-    config.as[String]("pennsieve.changelog.sns_topic").orElse("").toString()
+    config.as[Option[String]]("pennsieve.changelog.sns_topic").getOrElse("")
 }
 
 object APIContainers {

--- a/api/src/main/scala/com/pennsieve/helpers/BootstrapHelper.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/BootstrapHelper.scala
@@ -82,7 +82,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait ApiSQSContainer { self: Container =>
   val sqs_queue: String = config.as[String]("sqs.queue")
   val sqs_queue_v2: String =
-    config.as[Option[String]]("sqs.queue_v2").getOrElse("")
+    config.as[String]("sqs.queue_v2")
 }
 
 trait ApiSNSContainer { self: Container =>


### PR DESCRIPTION
## Changes Proposed

Assume that the config value for `sqs.queue_v2` exists and fail otherwise.

Also fixes a problem with reading `pennsieve.changelog.sns_topic` that never seemed to have caused a problem. Maybe because the value is unused? The `orElse("").toString()` usage causes the value to be set to the name of the partial function returned by `orElse("")` rather than the config value or empty string.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
