### PR TITLE
Set Content-Disposition on pre-signed AWS URLs

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataCanvasController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataCanvasController.scala
@@ -1021,7 +1021,8 @@ class DataCanvasController(
                     .getPresignedUrl(
                       p.s3Bucket,
                       p.s3Key,
-                      DateTime.now.plusMinutes(180).toDate
+                      DateTime.now.plusMinutes(180).toDate,
+                      p.packageName
                     )
                     .toOption
                     .get,

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -941,7 +941,8 @@ class PackagesController(
                     .getPresignedUrl(
                       p.s3Bucket,
                       p.s3Key,
-                      DateTime.now.plusMinutes(180).toDate
+                      DateTime.now.plusMinutes(180).toDate,
+                      p.packageName
                     )
                     .toOption
                     .get,
@@ -1522,7 +1523,8 @@ class PackagesController(
             .getPresignedUrl(
               file.s3Bucket,
               file.s3Key,
-              DateTime.now.plusMinutes(Settings.url_time_limit).toDate
+              DateTime.now.plusMinutes(Settings.url_time_limit).toDate,
+              pkg.name
             )
             .toEitherT[Future]
         else
@@ -1537,7 +1539,8 @@ class PackagesController(
               .getPresignedUrl(
                 file.s3Bucket,
                 file.s3Key,
-                DateTime.now.plusMinutes(Settings.bitly_url_time_limit).toDate
+                DateTime.now.plusMinutes(Settings.bitly_url_time_limit).toDate,
+                pkg.name
               )
               .toEitherT[Future]
             shortUrl <- EitherT.right[ActionResult](
@@ -1626,7 +1629,8 @@ class PackagesController(
           .getPresignedUrl(
             file.s3Bucket,
             s"${file.s3Key}$fileName",
-            DateTime.now.plusHours(10).toDate
+            DateTime.now.plusHours(10).toDate,
+            pkg.name
           )
           .toEitherT[Future]
       } yield url

--- a/api/src/test/scala/com/pennsieve/helpers/MockObjectStore.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/MockObjectStore.scala
@@ -29,7 +29,8 @@ class MockObjectStore(fileName: String) extends ObjectStore {
   def getPresignedUrl(
     bucket: String,
     key: String,
-    duration: Date
+    duration: Date,
+    fileName: String
   ): Either[ActionResult, URL] = {
     Right(new URL(s"file://$bucket/$key"))
   }

--- a/core/src/main/scala/com/pennsieve/clients/UrlShortenerClient.scala
+++ b/core/src/main/scala/com/pennsieve/clients/UrlShortenerClient.scala
@@ -76,7 +76,12 @@ class BitlyUrlShortenerClient(
         case error =>
           Unmarshal(error.entity)
             .to[String]
-            .flatMap(msg => Future.failed(new Exception(s"error shortening long url [$longUrl]: $msg")))
+            .flatMap(
+              msg =>
+                Future.failed(
+                  new Exception(s"error shortening long url [$longUrl]: $msg")
+                )
+            )
       }
     } yield shortUrl
   }

--- a/core/src/main/scala/com/pennsieve/clients/UrlShortenerClient.scala
+++ b/core/src/main/scala/com/pennsieve/clients/UrlShortenerClient.scala
@@ -76,7 +76,7 @@ class BitlyUrlShortenerClient(
         case error =>
           Unmarshal(error.entity)
             .to[String]
-            .flatMap(msg => Future.failed(new Exception(msg)))
+            .flatMap(msg => Future.failed(new Exception(s"error shortening long url [$longUrl]: $msg")))
       }
     } yield shortUrl
   }


### PR DESCRIPTION
## Changes Proposed

Sets the `Content-Disposition` header for pre-signed URLs to `attachement; filename="`_\<package name\>_`"` so that users see the name they are expecting rather than the S3 UUID key.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
