### PR TITLE
Filter out DELETED and RESTORING packages when populating storage cache

### DIFF
--- a/core/src/main/scala/com/pennsieve/db/PackageStorageTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/PackageStorageTable.scala
@@ -102,7 +102,9 @@ class PackageStorageMapper(val organization: Organization)
          AND files.object_type = ${FileObjectType.Source.entryName}
          AND packages.state NOT IN (
            ${PackageState.UNAVAILABLE.entryName},
-           ${PackageState.DELETING.entryName}
+           ${PackageState.DELETING.entryName},
+           ${PackageState.DELETED.entryName},
+           ${PackageState.RESTORING.entryName}
          )
          GROUP BY packages.id
        UNION ALL
@@ -113,7 +115,11 @@ class PackageStorageMapper(val organization: Organization)
            -- child packages to still set sizes, as long as those sizes don't
            -- propagate up the tree.
            CASE
-             WHEN parents.state = ${PackageState.DELETING.entryName}
+             WHEN parents.state IN (
+              ${PackageState.DELETING.entryName}, 
+              ${PackageState.DELETED.entryName},
+              ${PackageState.RESTORING.entryName}
+             )
              THEN NULL
              ELSE children.size
            END,


### PR DESCRIPTION
## Changes Proposed

Updates the SQL used to populate the package storage cache to filter out packages in the DELETED and RESTORING states. Query was already filtering out DELETING.

