### PR TITLE
Filter out RESTORING packages from dataset children

### DIFF
--- a/core/src/main/scala/com/pennsieve/db/PackagesTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/PackagesTable.scala
@@ -162,7 +162,7 @@ class PackagesMapper(val organization: Organization)
   }
 
   /*
-   * Note: This query excludes packages in the DELETING state
+   * Note: This query excludes packages in the DELETING, DELETED, and RESTORING states
    */
   def children(
     parent: Option[Package],
@@ -173,6 +173,7 @@ class PackagesMapper(val organization: Organization)
       .filter(_.datasetId === dataset.id)
       .filter(_.state =!= (PackageState.DELETING: PackageState))
       .filter(_.state =!= (PackageState.DELETED: PackageState))
+      .filter(_.state =!= (PackageState.RESTORING: PackageState))
 
   def hasParent(
     that: PackagesTable,

--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -677,6 +677,7 @@ class PackageManager(datasetManager: DatasetManager) {
         .filter(p => p.datasetId === dataset.id)
         .filter(_.state =!= (PackageState.DELETING: PackageState))
         .filter(_.state =!= (PackageState.DELETED: PackageState))
+        .filter(_.state =!= (PackageState.RESTORING: PackageState))
         .groupBy(p => p.`type`)
         .map { case (group, result) => (group, result.length) }
         .result


### PR DESCRIPTION
## Changes Proposed
Filters out packages with the new RESTORING state from queries used to return dataset children. These files should not be returned when a dataset's children are requested since they will not be available until the restore is complete.

