### PR TITLE
API: Adding pagination to files

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -424,12 +424,16 @@ class DataSetsController(
       case Some(etag) => checkIfMatchTimestamp(entity, etag)
     }
   }
+  
+  //Default values for retrieving Dataset children (i.e. packages)
+  //val DatasetChildrenDefaultLimit: Int = 25
+  //val DatasetChildrenDefaultOffset: Int = 0
 
   get(
     "/:id",
     operation(
       apiOperation[DataSetDTO]("getDataSet")
-        summary "gets a data set"
+        summary "gets a data set and paginates its children"
         parameters (
           pathParam[String]("id").description("data set id"),
           queryParam[Boolean]("includePublishedDataset").optional
@@ -437,12 +441,22 @@ class DataSetsController(
               "If true, information about publication will be returned"
             )
             .defaultValue(false)
+          //queryParam[Int]("limit").optional
+          //  .description("max number of dataset children (i.e. packages) returned")
+          //  .defaultValue(DatasetChildrenDefaultLimit)
+          //queryParam[Int]("offset").optional
+          //  .description("offset used for pagination of children")
+          //  .defaultValue(DatasetChildrenDefaultOffset)
       )
     )
   ) {
     new AsyncResult {
       val result: EitherT[Future, ActionResult, DataSetDTO] = for {
         datasetId <- paramT[String]("id")
+
+        //limit <- paramT[Int]("limit", default = DatasetChildrenDefaultLimit)
+        //offset <- paramT[Int]("offset", default = DatasetChildrenDefaultOffset)
+
         secureContainer <- getSecureContainer()
         traceId <- getTraceId(request)
         storageServiceClient = secureContainer.storageManager
@@ -1546,7 +1560,11 @@ class DataSetsController(
           datasetNodeId <- paramT[String]("id")
 
           dataset <- secureContainer.datasetManager
-            .getByNodeId(datasetNodeId)
+            .getByNodeId(
+              datasetNodeId,
+              //limit = limit.some,
+              //offset = offset.some
+              )
             .coreErrorToActionResult()
 
           _ <- secureContainer

--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -426,8 +426,8 @@ class DataSetsController(
   }
   
   //Default values for retrieving Dataset children (i.e. packages)
-  //val DatasetChildrenDefaultLimit: Int = 25
-  //val DatasetChildrenDefaultOffset: Int = 0
+  val DatasetChildrenDefaultLimit: Int = 25
+  val DatasetChildrenDefaultOffset: Int = 0
 
   get(
     "/:id",
@@ -441,12 +441,12 @@ class DataSetsController(
               "If true, information about publication will be returned"
             )
             .defaultValue(false)
-          //queryParam[Int]("limit").optional
-          //  .description("max number of dataset children (i.e. packages) returned")
-          //  .defaultValue(DatasetChildrenDefaultLimit)
-          //queryParam[Int]("offset").optional
-          //  .description("offset used for pagination of children")
-          //  .defaultValue(DatasetChildrenDefaultOffset)
+          queryParam[Int]("limit").optional
+            .description("max number of dataset children (i.e. packages) returned")
+            .defaultValue(DatasetChildrenDefaultLimit)
+          queryParam[Int]("offset").optional
+            .description("offset used for pagination of children")
+            .defaultValue(DatasetChildrenDefaultOffset)
       )
     )
   ) {
@@ -454,8 +454,8 @@ class DataSetsController(
       val result: EitherT[Future, ActionResult, DataSetDTO] = for {
         datasetId <- paramT[String]("id")
 
-        //limit <- paramT[Int]("limit", default = DatasetChildrenDefaultLimit)
-        //offset <- paramT[Int]("offset", default = DatasetChildrenDefaultOffset)
+        limit <- paramT[Int]("limit", default = DatasetChildrenDefaultLimit)
+        offset <- paramT[Int]("offset", default = DatasetChildrenDefaultOffset)
 
         secureContainer <- getSecureContainer()
         traceId <- getTraceId(request)
@@ -531,7 +531,7 @@ class DataSetsController(
           .coreErrorToActionResult()
 
         _ <- setETagHeader(dataset.etag)
-      } yield dto
+      } yield dto //here add a caseclass for paginated dataset PaginatedDataset(limit, offset, dtos)
 
       override val is = result.value.map(OkResult(_))
     }

--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -505,6 +505,8 @@ class DataSetsController(
         dto <- datasetDTO(
           dataset,
           status,
+          limit = limit.some,
+          offset = offset.some,
           includeChildren = true,
           storage = storage,
           datasetPublicationStatus = publicationStatus,

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -395,6 +395,10 @@ class PackagesController(
     }
   }
 
+  //Default values for retrieving Package children (i.e. other packages)
+  //val PackageChildrenDefaultLimit: Int = 25
+  //val PackageChildrenDefaultOffset: Int = 0
+
   val getPackageOperation = (apiOperation[PackageDTO]("getPackage")
     summary "gets a package and optionally objects that are associated with it"
     parameters (
@@ -408,6 +412,12 @@ class PackagesController(
         .description(
           "if the package contains channels, reset the channels to start at 0"
         )
+      //queryParam[Int]("limit").optional
+        //  .description("max number of dataset children (i.e. packages) returned")
+        //  .defaultValue(PackageChildrenDefaultLimit)
+      //queryParam[Int]("offset").optional
+        //  .description("offset used for pagination of children")
+        //  .defaultValue(PackageChildrenDefaultOffset)       
   ))
 
   get("/:id", operation(getPackageOperation)) {
@@ -477,6 +487,8 @@ class PackagesController(
       val result: EitherT[Future, ActionResult, PackageDTO] = for {
         secureContainer <- getSecureContainer()
         packageId <- paramT[String]("id")
+        //limit <- paramT[Int]("limit", default = PackageChildrenDefaultLimit
+        //offset <- paramT[Int]("offset", default = PackageChildrenDefaultOffset)
         traceId <- getTraceId(request)
         result <- secureContainer.packageManager
           .getPackageAndDatasetByNodeId(packageId)

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -116,6 +116,11 @@ case class SetStorageRequest(size: Long)
 
 case class SetStorageResponse(storageUse: Map[String, Long])
 
+object PackagesController {
+  //Default values for retrieving Package children (i.e. other packages)
+  val PackageChildrenDefaultLimit: Int = 25
+  val PackageChildrenDefaultOffset: Int = 0
+}
 
 class PackagesController(
   val insecureContainer: InsecureAPIContainer,
@@ -396,10 +401,6 @@ class PackagesController(
     }
   }
 
-  //Default values for retrieving Package children (i.e. other packages)
-  val PackageChildrenDefaultLimit: Int = 25
-  val PackageChildrenDefaultOffset: Int = 0
-
   val getPackageOperation = (apiOperation[PackageDTO]("getPackage")
     summary "gets a package and optionally objects that are associated with it"
     parameters (
@@ -412,13 +413,13 @@ class PackagesController(
         .defaultValue(false)
         .description(
           "if the package contains channels, reset the channels to start at 0"
-        )
+        ),
       queryParam[Int]("limit").optional
         .description("max number of dataset children (i.e. packages) returned")
-        .defaultValue(PackageChildrenDefaultLimit)
+        .defaultValue(PackagesController.PackageChildrenDefaultLimit),
       queryParam[Int]("offset").optional
         .description("offset used for pagination of children")
-        .defaultValue(PackageChildrenDefaultOffset)       
+        .defaultValue(PackagesController.PackageChildrenDefaultOffset)
   ))
 
   get("/:id", operation(getPackageOperation)) {
@@ -488,8 +489,14 @@ class PackagesController(
       val result: EitherT[Future, ActionResult, PackageDTO] = for {
         secureContainer <- getSecureContainer()
         packageId <- paramT[String]("id")
-        limit <- paramT[Int]("limit", default = PackageChildrenDefaultLimit)
-        offset <- paramT[Int]("offset", default = PackageChildrenDefaultOffset)
+        limit <- paramT[Int](
+          "limit",
+          default = PackagesController.PackageChildrenDefaultLimit
+        )
+        offset <- paramT[Int](
+          "offset",
+          default = PackagesController.PackageChildrenDefaultOffset
+        )
         traceId <- getTraceId(request)
         result <- secureContainer.packageManager
           .getPackageAndDatasetByNodeId(packageId)
@@ -535,12 +542,12 @@ class PackagesController(
         dto <- packageDTO(
           updatedPackage,
           dataset,
-          limit.some,
-          offset.some,
           includeAncestors,
           includeChildren,
           include,
-          storage = storage
+          storage = storage,
+          limit = limit.some,
+          offset = offset.some
         )(asyncExecutor, secureContainer).orError()
 
         _ <- auditLogger

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -396,8 +396,8 @@ class PackagesController(
   }
 
   //Default values for retrieving Package children (i.e. other packages)
-  //val PackageChildrenDefaultLimit: Int = 25
-  //val PackageChildrenDefaultOffset: Int = 0
+  val PackageChildrenDefaultLimit: Int = 25
+  val PackageChildrenDefaultOffset: Int = 0
 
   val getPackageOperation = (apiOperation[PackageDTO]("getPackage")
     summary "gets a package and optionally objects that are associated with it"
@@ -412,12 +412,12 @@ class PackagesController(
         .description(
           "if the package contains channels, reset the channels to start at 0"
         )
-      //queryParam[Int]("limit").optional
-        //  .description("max number of dataset children (i.e. packages) returned")
-        //  .defaultValue(PackageChildrenDefaultLimit)
-      //queryParam[Int]("offset").optional
-        //  .description("offset used for pagination of children")
-        //  .defaultValue(PackageChildrenDefaultOffset)       
+      queryParam[Int]("limit").optional
+        .description("max number of dataset children (i.e. packages) returned")
+        .defaultValue(PackageChildrenDefaultLimit)
+      queryParam[Int]("offset").optional
+        .description("offset used for pagination of children")
+        .defaultValue(PackageChildrenDefaultOffset)       
   ))
 
   get("/:id", operation(getPackageOperation)) {
@@ -487,8 +487,8 @@ class PackagesController(
       val result: EitherT[Future, ActionResult, PackageDTO] = for {
         secureContainer <- getSecureContainer()
         packageId <- paramT[String]("id")
-        //limit <- paramT[Int]("limit", default = PackageChildrenDefaultLimit
-        //offset <- paramT[Int]("offset", default = PackageChildrenDefaultOffset)
+        limit <- paramT[Int]("limit", default = PackageChildrenDefaultLimit
+        offset <- paramT[Int]("offset", default = PackageChildrenDefaultOffset)
         traceId <- getTraceId(request)
         result <- secureContainer.packageManager
           .getPackageAndDatasetByNodeId(packageId)

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -116,6 +116,7 @@ case class SetStorageRequest(size: Long)
 
 case class SetStorageResponse(storageUse: Map[String, Long])
 
+
 class PackagesController(
   val insecureContainer: InsecureAPIContainer,
   val secureContainerBuilder: SecureContainerBuilderType,
@@ -487,7 +488,7 @@ class PackagesController(
       val result: EitherT[Future, ActionResult, PackageDTO] = for {
         secureContainer <- getSecureContainer()
         packageId <- paramT[String]("id")
-        limit <- paramT[Int]("limit", default = PackageChildrenDefaultLimit
+        limit <- paramT[Int]("limit", default = PackageChildrenDefaultLimit)
         offset <- paramT[Int]("offset", default = PackageChildrenDefaultOffset)
         traceId <- getTraceId(request)
         result <- secureContainer.packageManager
@@ -534,6 +535,8 @@ class PackagesController(
         dto <- packageDTO(
           updatedPackage,
           dataset,
+          limit.some,
+          offset.some,
           includeAncestors,
           includeChildren,
           include,

--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -287,6 +287,63 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
     }
   }
 
+  test("get dataset returns default number of paginated children") {
+    // create a dataset
+    val ds = createDataSet(
+      name = "test-dataset-for-paginated-children",
+      description = Some("test-dataset-for-paginated-children")
+    )
+    // add packages to the dataset
+    (1 to 26).map(n => createPackage(ds, s"Package-${n}"))
+
+    get(
+      s"/${ds.nodeId}",
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(200)
+      val dataset = parsedBody.extract[DataSetDTO]
+      dataset.children.get.length shouldBe DataSetsController.DatasetChildrenDefaultLimit
+    }
+  }
+
+  test("get dataset returns requested number of paginated children") {
+    // create a dataset
+    val ds = createDataSet(
+      name = "test-dataset-for-paginated-children",
+      description = Some("test-dataset-for-paginated-children")
+    )
+    // add packages to the dataset
+    (1 to 26).map(n => createPackage(ds, s"Package-${n}"))
+
+    get(
+      s"/${ds.nodeId}?offset=0&limit=5",
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(200)
+      val dataset = parsedBody.extract[DataSetDTO]
+      dataset.children.get.length shouldBe 5
+    }
+  }
+
+  test("get dataset returns partial limit when on the last page") {
+    // create a dataset
+    val ds = createDataSet(
+      name = "test-dataset-for-paginated-children",
+      description = Some("test-dataset-for-paginated-children")
+    )
+    // add packages to the dataset
+    (1 to 26).map(n => createPackage(ds, s"Package-${n}"))
+
+    get(
+      s"/${ds.nodeId}?offset=25&limit=5",
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
+    ) {
+      status should equal(200)
+      val dataset = parsedBody.extract[DataSetDTO]
+      dataset.children.get.length shouldBe 1
+    }
+  }
+
   test("get a data set for an external file") {
     val description = Some("An external file")
     val externalLocation = Some("https://drive.google.com/external_file")

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -211,6 +211,8 @@ object Builders {
   ](
     dataset: Dataset,
     status: DatasetStatus,
+    limit: Int,
+    offset: Int,
     datasetPublicationStatus: Option[DatasetPublicationStatus],
     contributors: Seq[Contributor],
     includeChildren: Boolean = false,
@@ -232,7 +234,7 @@ object Builders {
     for {
 
       children <- if (includeChildren) {
-        childrenPackageDTOs(None, dataset).map(Some.apply)
+        childrenPackageDTOs(None, dataset, limit = limit.some, offset = offset.some).map(Some.apply)
       } else {
         Future[Option[List[PackageDTO]]](None).toEitherT
       }
@@ -295,7 +297,9 @@ object Builders {
 
   def childrenPackageDTOs[DIContainer <: PackageDTODIContainer](
     parent: Option[Package],
-    dataset: Dataset
+    dataset: Dataset,
+    limit: Option[Int],
+    offset: Option[Int],
   )(implicit
     executionContext: ExecutionContext,
     secureContainer: DIContainer
@@ -377,6 +381,8 @@ object Builders {
   def packageDTO[DIContainer <: PackageDTODIContainer](
     `package`: Package,
     dataset: Dataset,
+    limit: Int,
+    offset: Int,
     includeAncestors: Boolean = false,
     includeChildren: Boolean = true,
     include: Option[Set[FileObjectType]] = None, //"None" indicates that we should not return any of the objects
@@ -417,7 +423,7 @@ object Builders {
       }
 
       childPackageDTOs <- {
-        if (includeChildren) childrenPackageDTOs(Some(`package`), dataset)
+        if (includeChildren) childrenPackageDTOs(Some(`package`), dataset, limit = limit.some, offset = offset.some)
         else Right(List.empty[PackageDTO]).toEitherT[Future]
       }
 

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -348,14 +348,14 @@ class DatasetManager(
       .getOrElse(getByNodeId(nodeOrIntId))
 
   def getByNodeId(
-    nodeId: String,
+    nodeId: String
     //limit: Option[Int],
     //offset: Option[Int]
   )(implicit
     ec: ExecutionContext
-  ): EitherT[Future, CoreError, Dataset] = 
+  ): EitherT[Future, CoreError, Dataset] =
     //{INCLUDE QUERY HERE:
-      //apply query used to get paginated datasets, but on the children of dataset...
+    //apply query used to get paginated datasets, but on the children of dataset...
     //}
     db.run(
         datasetsMapper.withoutDeleted

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -348,10 +348,15 @@ class DatasetManager(
       .getOrElse(getByNodeId(nodeOrIntId))
 
   def getByNodeId(
-    nodeId: String
+    nodeId: String,
+    //limit: Option[Int],
+    //offset: Option[Int]
   )(implicit
     ec: ExecutionContext
-  ): EitherT[Future, CoreError, Dataset] =
+  ): EitherT[Future, CoreError, Dataset] = 
+    //{INCLUDE QUERY HERE:
+      //apply query used to get paginated datasets, but on the children of dataset...
+    //}
     db.run(
         datasetsMapper.withoutDeleted
           .filter(_.nodeId === nodeId)

--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -481,17 +481,51 @@ class PackageManager(datasetManager: DatasetManager) {
 
   def children(
     parent: Option[Package],
-    dataset: Dataset
+    dataset: Dataset,
+    offset: Option[Int],
+    limit: Option[Int]
   )(implicit
     ec: ExecutionContext
-  ): EitherT[Future, CoreError, List[Package]] =
-    db.run(
+  ): EitherT[Future, CoreError, List[Package]] = /* {
+
+    val query =
+      packagesMapper
+        .filter { pkg =>
+          pkg.dataset === dataset.id &&
+          pkg.parentId === parent.map(_.id)
+        }
+        .sortBy(_.name)
+    
+    val queryWithSort =
+      parent.fold(query)(p => query.sortBy(pkg => (pkg.parentId.isEmpty, pkg.name)))
+    
+    val queryWithOffset =
+      offset.foldLeft(queryWithSort) { (query, offset) =>
+        query.drop(offset)
+      }
+
+    val finalQuery = limit
+      .foldLeft(queryWithOffset) { (query, limit) =>
+        query.take(limit)
+      }
+
+      db.run(finalQuery.result)
+      .map(_.toList)
+      .toEitherT
+      */
+      
+      //ORIGINAL:
+      """"
+          db.run(
         packagesMapper
           .children(parent, dataset)
           .result
       )
       .map(_.toList)
       .toEitherT
+      """"
+  }
+
 
   def checkName(
     name: String,

--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -486,7 +486,7 @@ class PackageManager(datasetManager: DatasetManager) {
     limit: Option[Int]
   )(implicit
     ec: ExecutionContext
-  ): EitherT[Future, CoreError, List[Package]] = /* {
+  ): EitherT[Future, CoreError, List[Package]] =  {
 
     val query =
       packagesMapper
@@ -495,10 +495,11 @@ class PackageManager(datasetManager: DatasetManager) {
           pkg.parentId === parent.map(_.id)
         }
         .sortBy(_.name)
-    
+    //we want the results to return in order
     val queryWithSort =
       parent.fold(query)(p => query.sortBy(pkg => (pkg.parentId.isEmpty, pkg.name)))
     
+    //taking 'limit' numeber of children starting at 'offset'
     val queryWithOffset =
       offset.foldLeft(queryWithSort) { (query, offset) =>
         query.drop(offset)
@@ -512,7 +513,7 @@ class PackageManager(datasetManager: DatasetManager) {
       db.run(finalQuery.result)
       .map(_.toList)
       .toEitherT
-      */
+      
       
       //ORIGINAL:
       """"


### PR DESCRIPTION
## Changes Proposed

Adds pagination to:
- GET Dataset by NodeId, returning "children" (top-level Packages)
- GET Package by NodeId, returning "children" (contained Packages in a Collection)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
