### PR TITLE
Support undelete ChangelogEventDetails

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/ChangelogEventDetail.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/ChangelogEventDetail.scala
@@ -64,6 +64,7 @@ object ChangelogEventDetail {
       case d: RenamePackage => d.asJson
       case d: MovePackage => d.asJson
       case d: DeletePackage => d.asJson
+      case d: RestorePackage => d.asJson
       case d: CreateModel => d.asJson
       case d: UpdateModel => d.asJson
       case d: DeleteModel => d.asJson
@@ -122,6 +123,7 @@ object ChangelogEventDetail {
       case RENAME_PACKAGE => RenamePackage.decoder.widen
       case MOVE_PACKAGE => MovePackage.decoder.widen
       case DELETE_PACKAGE => DeletePackage.decoder.widen
+      case RESTORE_PACKAGE => RestorePackage.decoder.widen
       case CREATE_MODEL => CreateModel.decoder.widen
       case UPDATE_MODEL => UpdateModel.decoder.widen
       case DELETE_MODEL => DeleteModel.decoder.widen
@@ -590,6 +592,30 @@ object ChangelogEventDetail {
 
     implicit val encoder: Encoder[DeletePackage] = deriveEncoder[DeletePackage]
     implicit val decoder: Decoder[DeletePackage] = deriveDecoder[DeletePackage]
+  }
+
+  case class RestorePackage(
+    id: Int,
+    nodeId: Option[String],
+    name: Option[String],
+    parent: Option[PackageDetail]
+  ) extends ChangelogEventDetail {
+    val eventType = RESTORE_PACKAGE
+  }
+
+  object RestorePackage {
+    def apply(pkg: Package, parent: Option[Package]): RestorePackage =
+      RestorePackage(
+        id = pkg.id,
+        nodeId = Some(pkg.nodeId),
+        name = Some(pkg.name),
+        parent = parent.map(PackageDetail(_))
+      )
+
+    implicit val encoder: Encoder[RestorePackage] =
+      deriveEncoder[RestorePackage]
+    implicit val decoder: Decoder[RestorePackage] =
+      deriveDecoder[RestorePackage]
   }
 
   case class CreateModel(id: UUID, name: String) extends ChangelogEventDetail {

--- a/core-models/src/main/scala/com/pennsieve/models/ChangelogEventDetail.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/ChangelogEventDetail.scala
@@ -598,17 +598,23 @@ object ChangelogEventDetail {
     id: Int,
     nodeId: Option[String],
     name: Option[String],
+    originalName: Option[String],
     parent: Option[PackageDetail]
   ) extends ChangelogEventDetail {
     val eventType = RESTORE_PACKAGE
   }
 
   object RestorePackage {
-    def apply(pkg: Package, parent: Option[Package]): RestorePackage =
+    def apply(
+      pkg: Package,
+      originalName: Option[String],
+      parent: Option[Package]
+    ): RestorePackage =
       RestorePackage(
         id = pkg.id,
         nodeId = Some(pkg.nodeId),
         name = Some(pkg.name),
+        originalName = originalName,
         parent = parent.map(PackageDetail(_))
       )
 

--- a/core-models/src/main/scala/com/pennsieve/models/ChangelogEventName.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/ChangelogEventName.scala
@@ -111,6 +111,9 @@ object ChangelogEventName
   case object DELETE_PACKAGE extends ChangelogEventName {
     val category = PACKAGES
   }
+  case object RESTORE_PACKAGE extends ChangelogEventName {
+    val category = PACKAGES
+  }
 
   // MODELS, RECORDS
 

--- a/jobs/src/test/scala/com/pennsieve/jobs/types/DatasetChangelogEventJobSpec.scala
+++ b/jobs/src/test/scala/com/pennsieve/jobs/types/DatasetChangelogEventJobSpec.scala
@@ -134,7 +134,8 @@ class DatasetChangelogEventJobSpec
       |    "userId": "${u.nodeId}",
       |    "events": [
       |      {"eventType": "CREATE_PACKAGE", "eventDetail": { "id": 123, "timestamp": "2019-03-27T10:15:30+05:30" }},
-      |      {"eventType": "DELETE_PACKAGE", "eventDetail": { "id": 123 }}
+      |      {"eventType": "DELETE_PACKAGE", "eventDetail": { "id": 123 }},
+      |      {"eventType": "RESTORE_PACKAGE", "eventDetail": { "id": 123, "name": "test.txt" }}
       |    ],
       |    "traceId": "1234-5678",
       |    "id": "${UUID.randomUUID().toString}"
@@ -187,6 +188,25 @@ class DatasetChangelogEventJobSpec
     deleteEvents.head.eventType shouldBe (ChangelogEventName.DELETE_PACKAGE)
     deleteEvents.head.detail shouldBe (ChangelogEventDetail
       .DeletePackage(id = 123, None, None, None))
+
+    // RESTORE
+    val (undeleteEvents, _) = clm
+      .getEvents(
+        dataset = ds,
+        limit = 10,
+        cursor = ChangelogEventCursor(
+          ChangelogEventName.RESTORE_PACKAGE,
+          None,
+          None,
+          None
+        )
+      )
+      .await
+      .value
+    undeleteEvents.length shouldBe (1)
+    undeleteEvents.head.eventType shouldBe (ChangelogEventName.RESTORE_PACKAGE)
+    undeleteEvents.head.detail shouldBe (ChangelogEventDetail
+      .RestorePackage(id = 123, None, Some("test.txt"), None))
   }
 
   "parsing a changelog event job" should "fail if the event is not well-formed or missing data" in {

--- a/jobs/src/test/scala/com/pennsieve/jobs/types/DatasetChangelogEventJobSpec.scala
+++ b/jobs/src/test/scala/com/pennsieve/jobs/types/DatasetChangelogEventJobSpec.scala
@@ -135,7 +135,7 @@ class DatasetChangelogEventJobSpec
       |    "events": [
       |      {"eventType": "CREATE_PACKAGE", "eventDetail": { "id": 123, "timestamp": "2019-03-27T10:15:30+05:30" }},
       |      {"eventType": "DELETE_PACKAGE", "eventDetail": { "id": 123 }},
-      |      {"eventType": "RESTORE_PACKAGE", "eventDetail": { "id": 123, "name": "test.txt" }}
+      |      {"eventType": "RESTORE_PACKAGE", "eventDetail": { "id": 123, "name": "test.txt (1)", "originalName": "test.txt" }}
       |    ],
       |    "traceId": "1234-5678",
       |    "id": "${UUID.randomUUID().toString}"
@@ -206,7 +206,13 @@ class DatasetChangelogEventJobSpec
     undeleteEvents.length shouldBe (1)
     undeleteEvents.head.eventType shouldBe (ChangelogEventName.RESTORE_PACKAGE)
     undeleteEvents.head.detail shouldBe (ChangelogEventDetail
-      .RestorePackage(id = 123, None, Some("test.txt"), None))
+      .RestorePackage(
+        id = 123,
+        None,
+        Some("test.txt (1)"),
+        Some("test.txt"),
+        None
+      ))
   }
 
   "parsing a changelog event job" should "fail if the event is not well-formed or missing data" in {


### PR DESCRIPTION
## Changes Proposed

Adds a new ChangelogEventDetail subtype for undelete. 

Needed so that the Job server can correctly parse the JSON for undelete changelog events.

## Checklist

- [x] unit tests added and/or verified that tests pass
