### PR TITLE
Publishing 5.0 feature - fix dataset asset target S3 path

### DIFF
--- a/discover-publish/src/main/scala/com/pennsieve/publish/ComputeFileActions.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/ComputeFileActions.scala
@@ -13,3 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -108,7 +108,13 @@ object Publish extends StrictLogging {
     assetKey(config, METADATA_FILENAME)
 
   private def publicAssetKeyPrefix(container: PublishContainer): String =
-    joinKeys(Seq(container.s3AssetKeyPrefix, container.publishedDatasetId.toString, container.version.toString))
+    joinKeys(
+      Seq(
+        container.s3AssetKeyPrefix,
+        container.publishedDatasetId.toString,
+        container.version.toString
+      )
+    )
 
   /**
     * These intermediate files are generated as part of publishing. After the `finalizeDataset` step runs, they should

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -107,6 +107,9 @@ object Publish extends StrictLogging {
   private def publishedMetadataKey(config: PublishContainerConfig): String =
     assetKey(config, METADATA_FILENAME)
 
+  private def publicAssetKeyPrefix(container: PublishContainer): String =
+    joinKeys(Seq(container.s3AssetKeyPrefix, container.publishedDatasetId.toString, container.version.toString))
+
   /**
     * These intermediate files are generated as part of publishing. After the `finalizeDataset` step runs, they should
     * be deleted.
@@ -404,20 +407,20 @@ object Publish extends StrictLogging {
       bannerName = s"banner$extension"
       bannerKey = joinKeys(container.s3Key, bannerName)
 
-      // Copy to public asset bucket
+      // Copy to public asset bucket: always has dataset-id/dataset-version in path
       _ <- container.s3
         .copyObject(
           new CopyObjectRequest(
             banner.s3Bucket,
             banner.s3Key,
             container.s3AssetBucket,
-            joinKeys(container.s3AssetKeyPrefix, bannerKey)
+            joinKeys(publicAssetKeyPrefix(container), bannerName)
           )
         )
         .toEitherT[Future]
         .leftMap[CoreError](ThrowableError)
 
-      // Copy to published dataset bucket
+      // Copy to published dataset bucket: uses container.s3Key as head of path (see above)
       _ <- container.s3
         .copyObject(
           new CopyObjectRequest(
@@ -472,14 +475,14 @@ object Publish extends StrictLogging {
           )
         )
 
-      // Copy to public asset bucket
+      // Copy to public asset bucket: always has dataset-id/dataset-version in path
       _ <- container.s3
         .copyObject(
           new CopyObjectRequest(
             readme.s3Bucket,
             readme.s3Key,
             container.s3AssetBucket,
-            joinKeys(container.s3AssetKeyPrefix, readmeKey)
+            joinKeys(publicAssetKeyPrefix(container), README_FILENAME)
           )
         )
         .toEitherT[Future]
@@ -550,14 +553,14 @@ object Publish extends StrictLogging {
             )
         )
 
-      // Copy to public asset bucket
+      // Copy to public asset bucket: always has dataset-id/dataset-version in path
       _ <- container.s3
         .copyObject(
           new CopyObjectRequest(
             changelog.s3Bucket,
             changelog.s3Key,
             container.s3AssetBucket,
-            joinKeys(container.s3AssetKeyPrefix, changelogKey)
+            joinKeys(publicAssetKeyPrefix(container), CHANGELOG_FILENAME)
           )
         )
         .toEitherT[Future]

--- a/discover-publish/terraform/steps.tf
+++ b/discover-publish/terraform/steps.tf
@@ -14,7 +14,10 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
         "publish_bucket.$": "$.publish_bucket",
         "embargo_bucket.$": "$.embargo_bucket",
         "s3_key_prefix.$": "$.s3_publish_key",
-        "workflow_id.$": "$.workflow_id"
+        "workflow_id.$": "$.workflow_id",
+        "published_dataset_id.$": "$.published_dataset_id",
+        "published_dataset_version.$": "$.version",
+        "cleanup_stage.$": "INITIAL"
       },
       "Retry": [
         {
@@ -348,7 +351,10 @@ resource "aws_sfn_state_machine" "sfn_state_machine" {
         "publish_bucket.$": "$.publish_bucket",
         "embargo_bucket.$": "$.embargo_bucket",
         "s3_key_prefix.$": "$.s3_publish_key",
-        "workflow_id.$": "$.workflow_id"
+        "workflow_id.$": "$.workflow_id",
+        "published_dataset_id.$": "$.published_dataset_id",
+        "published_dataset_version.$": "$.version",
+        "cleanup_stage.$": "FAILURE"
       },
       "Retry": [
         {


### PR DESCRIPTION
## Changes Proposed

- compute path/key for Public Assets bucket: banner, readme, changelog
- add parameters to S3 Clean Lambda

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
