### PR TITLE
Publishing 5.0 feature - defer delete of intermediate files

### DIFF
--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -287,18 +287,18 @@ object Publish extends StrictLogging {
         ).asJson
       )
 
-      _ = logger.info(
-        s"Deleting temporary files: $PUBLISH_ASSETS_FILENAME, $GRAPH_ASSETS_FILENAME"
-      )
-
-      _ <- container.s3
-        .deleteObjectsByKeys(
-          container.s3Bucket,
-          Seq(publishedAssetsKey(container), graphManifestKey(container)),
-          isRequesterPays = true
-        )
-        .toEitherT[Future]
-        .leftMap[CoreError](t => ExceptionError(new Exception(t)))
+//      _ = logger.info(
+//        s"Deleting temporary files: $PUBLISH_ASSETS_FILENAME, $GRAPH_ASSETS_FILENAME"
+//      )
+//
+//      _ <- container.s3
+//        .deleteObjectsByKeys(
+//          container.s3Bucket,
+//          Seq(publishedAssetsKey(container), graphManifestKey(container)),
+//          isRequesterPays = true
+//        )
+//        .toEitherT[Future]
+//        .leftMap[CoreError](t => ExceptionError(new Exception(t)))
 
     } yield ()
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -563,12 +563,12 @@ class TestPublish
       runModelPublish(publishBucket, testKey)
 
       Publish.finalizeDataset(publishContainer).await shouldBe Right(())
-      // Ensure all temporary files should be deleted by now:
-      for (tempFile <- Publish.temporaryFiles) {
-        assert(
-          Try(downloadFile(publishBucket, testKey + tempFile)).toEither.isLeft
-        )
-      }
+//      // Ensure all temporary files should be deleted by now:
+//      for (tempFile <- Publish.temporaryFiles) {
+//        assert(
+//          Try(downloadFile(publishBucket, testKey + tempFile)).toEither.isLeft
+//        )
+//      }
     }
 
     "create metadata, package objects and public assets in S3 (publish bucket)" in {
@@ -632,12 +632,12 @@ class TestPublish
       assert(
         Try(downloadFile(publishBucket, testKey + "outputs.json")).toEither.isRight
       )
-      assert(
-        Try(downloadFile(publishBucket, testKey + "publish.json")).toEither.isLeft
-      )
-      assert(
-        Try(downloadFile(publishBucket, testKey + "graph.json")).toEither.isLeft
-      )
+//      assert(
+//        Try(downloadFile(publishBucket, testKey + "publish.json")).toEither.isLeft
+//      )
+//      assert(
+//        Try(downloadFile(publishBucket, testKey + "graph.json")).toEither.isLeft
+//      )
 
       // should write a temp results file to publish bucket
       val tempResults = decode[Publish.TempPublishResults](
@@ -810,12 +810,12 @@ class TestPublish
       assert(
         Try(downloadFile(embargoBucket, testKey + "outputs.json")).toEither.isRight
       )
-      assert(
-        Try(downloadFile(embargoBucket, testKey + "publish.json")).toEither.isLeft
-      )
-      assert(
-        Try(downloadFile(embargoBucket, testKey + "graph.json")).toEither.isLeft
-      )
+//      assert(
+//        Try(downloadFile(embargoBucket, testKey + "publish.json")).toEither.isLeft
+//      )
+//      assert(
+//        Try(downloadFile(embargoBucket, testKey + "graph.json")).toEither.isLeft
+//      )
 
       // should write a temp results file to publish bucket
       val tempResults = decode[Publish.TempPublishResults](

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublishS3Requests.scala
@@ -270,9 +270,9 @@ class TestPublishS3Requests
         .expects(capture(putObjectCapture))
         .twice()
 
-      (mockAmazonS3
-        .deleteObjects(_: DeleteObjectsRequest))
-        .expects(capture(deleteObjectsCapture))
+//      (mockAmazonS3
+//        .deleteObjects(_: DeleteObjectsRequest))
+//        .expects(capture(deleteObjectsCapture))
 
       Publish
         .finalizeDataset(publishContainer)


### PR DESCRIPTION
## Changes Proposed

- do not delete `publish.json` or `graph.json` in **Finalize** stage

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
