### PR TITLE
Publishing 5.0 feature - fix path to S3 Object in FileActions export

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -3966,7 +3966,10 @@ class DataSetsController(
       pathParam[String]("id").description("data set id")
     ))
 
-  get("/:id/publication/data-use-agreement", operation(getPublicationDataUseAgreement)) {
+  get(
+    "/:id/publication/data-use-agreement",
+    operation(getPublicationDataUseAgreement)
+  ) {
     new AsyncResult {
       val result: EitherT[Future, ActionResult, Option[DataUseAgreementDTO]] =
         for {

--- a/api/src/main/scala/com/pennsieve/api/UserController.scala
+++ b/api/src/main/scala/com/pennsieve/api/UserController.scala
@@ -436,7 +436,7 @@ class UserController(
   val mergeUsersOperation = (apiOperation[UserDTO]("merge user accounts") summary "merge user accounts"
     parameter bodyParam[UserMergeRequest]("newUserToken").required
     parameter pathParam[String]("userId").required
-    .description("id of the user requested"))
+      .description("id of the user requested"))
 
   put("/merge/:userId", operation(mergeUsersOperation)) {
     new AsyncResult {

--- a/api/src/main/scala/com/pennsieve/web/ServletApp.scala
+++ b/api/src/main/scala/com/pennsieve/web/ServletApp.scala
@@ -34,8 +34,18 @@ object PennsieveAppInfo
       """Pennsieve Swagger""",
       """Swagger documentation for the Pennsieve api""",
       """https://docs.pennsieve.io/docs/pennsieve-terms-of-service""",
-      ContactInfo("Pennsieve Team", "https://docs.pennsieve.io", "support@pennsieve.net"),
+      ContactInfo(
+        "Pennsieve Team",
+        "https://docs.pennsieve.io",
+        "support@pennsieve.net"
+      ),
       LicenseInfo("All rights reserved", "https://docs.pennsieve.io")
     )
 
-class SwaggerApp extends Swagger("2.0", "1.0.0", host="api.pennsieve.io", apiInfo = PennsieveAppInfo)
+class SwaggerApp
+    extends Swagger(
+      "2.0",
+      "1.0.0",
+      host = "api.pennsieve.io",
+      apiInfo = PennsieveAppInfo
+    )

--- a/authorization-service/src/main/scala/com/pennsieve/authorization/routes/AuthorizationRoutes.scala
+++ b/authorization-service/src/main/scala/com/pennsieve/authorization/routes/AuthorizationRoutes.scala
@@ -19,33 +19,44 @@ package com.pennsieve.authorization.routes
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpHeader, HttpResponse}
+import akka.http.scaladsl.model.{ HttpHeader, HttpResponse }
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.Credentials
 import cats.implicits._
 import com.pennsieve.akka.http.RouteService
-import com.pennsieve.auth.middleware.{CognitoSession, DatasetId, DatasetNodeId, EncryptionKeyId, Jwt, OrganizationId, OrganizationNodeId, UserClaim, UserId, UserNodeId}
+import com.pennsieve.auth.middleware.{
+  CognitoSession,
+  DatasetId,
+  DatasetNodeId,
+  EncryptionKeyId,
+  Jwt,
+  OrganizationId,
+  OrganizationNodeId,
+  UserClaim,
+  UserId,
+  UserNodeId
+}
 import com.pennsieve.authorization.Router.ResourceContainer
 import com.pennsieve.authorization.utilities.exceptions._
 import com.pennsieve.aws.cognito.CognitoPayload
 import com.pennsieve.db._
-import com.pennsieve.dtos.{Builders, UserDTO}
+import com.pennsieve.dtos.{ Builders, UserDTO }
 import com.pennsieve.models._
 import com.pennsieve.traits.PostgresProfile.api._
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe._
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.syntax._
-import pdi.jwt.{JwtAlgorithm, JwtCirce, JwtClaim}
+import pdi.jwt.{ JwtAlgorithm, JwtCirce, JwtClaim }
 import shapeless.syntax.inject._
-import slick.dbio.{DBIOAction, Effect, NoStream}
+import slick.dbio.{ DBIOAction, Effect, NoStream }
 import slick.sql.FixedSqlStreamingAction
 
 import scala.collection.immutable
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Either, Failure, Success, Try}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Either, Failure, Success, Try }
 
 class AuthorizationRoutes(
   user: User,

--- a/discover-publish/src/main/scala/com/pennsieve/publish/ComputeFileActions.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/ComputeFileActions.scala
@@ -13,4 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-

--- a/discover-publish/src/main/scala/com/pennsieve/publish/models/CopyAction.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/models/CopyAction.scala
@@ -94,6 +94,12 @@ object FileActionItem {
 case class FileActionList(fileActionList: Seq[FileActionItem])
 
 object FileActionList {
+  def path(prefix: String, suffix: String): String =
+    prefix.endsWith("/") match {
+      case true => s"${prefix}${suffix}"
+      case false => s"${prefix}/${suffix}"
+    }
+
   def from(fileActions: Seq[FileAction]): FileActionList =
     new FileActionList(fileActionList = fileActions.map { fileAction =>
       fileAction match {
@@ -101,21 +107,21 @@ object FileActionList {
           FileActionItem(
             action = FileActionType.CopyFile,
             bucket = copyAction.toBucket,
-            path = s"${copyAction.baseKey}/${copyAction.fileKey}",
+            path = path(copyAction.baseKey, copyAction.fileKey),
             versionId = copyAction.s3VersionId
           )
         case keepAction: KeepAction =>
           FileActionItem(
             action = FileActionType.KeepFile,
             bucket = keepAction.bucket,
-            path = s"${keepAction.baseKey}/${keepAction.fileKey}",
+            path = path(keepAction.baseKey, keepAction.fileKey),
             versionId = keepAction.s3VersionId
           )
         case deleteAction: DeleteAction =>
           FileActionItem(
             action = FileActionType.DeleteFile,
             bucket = deleteAction.fromBucket,
-            path = s"${deleteAction.baseKey}/${deleteAction.fileKey}",
+            path = path(deleteAction.baseKey, deleteAction.fileKey),
             versionId = deleteAction.s3VersionId
           )
       }


### PR DESCRIPTION
## Changes Proposed

- remove duplicated '/' characters between prefix and file key

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
