### PR TITLE
Publishing 5.0 feature - add some logging

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
@@ -288,4 +288,24 @@ object FileManifest {
       sourcePackageId
     )
   }
+  def apply(
+    /**
+      * Used in older versions of the schema.
+      */
+    path: String,
+    size: Long,
+    fileType: FileType,
+    sourcePackageId: Option[String],
+    s3VersionId: Option[String]
+  ): FileManifest = {
+    FileManifest(
+      name = FilenameUtils.getName(path),
+      path = path,
+      size = size,
+      fileType = fileType,
+      sourcePackageId = sourcePackageId,
+      id = None,
+      s3VersionId = s3VersionId
+    )
+  }
 }

--- a/discover-publish/src/main/scala/com/pennsieve/publish/ExecuteS3ObjectActions.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/ExecuteS3ObjectActions.scala
@@ -50,21 +50,21 @@ object ExecuteS3ObjectActions extends LazyLogging {
     implicit val scheduler = system.scheduler
 
     Flow[FileAction]
-      .mapAsyncUnordered(container.s3CopyFileParallelism)(
-        fileAction =>
-          fileAction match {
-            case copyAction: CopyAction =>
-              retry(() => copyFile(copyAction), attempts = 5, delay = 5.second)
-            case deleteAction: DeleteAction =>
-              retry(
-                () => deleteFile(deleteAction),
-                attempts = 5,
-                delay = 5.second
-              )
-            case keepAction: KeepAction =>
-              retry(() => keepFile(keepAction), attempts = 5, delay = 5.second)
-          }
-      )
+      .mapAsyncUnordered(container.s3CopyFileParallelism) { fileAction =>
+        logger.info(s"ExecuteS3ObjectActions() fileAction: ${fileAction}")
+        fileAction match {
+          case copyAction: CopyAction =>
+            retry(() => copyFile(copyAction), attempts = 5, delay = 5.second)
+          case deleteAction: DeleteAction =>
+            retry(
+              () => deleteFile(deleteAction),
+              attempts = 5,
+              delay = 5.second
+            )
+          case keepAction: KeepAction =>
+            retry(() => keepFile(keepAction), attempts = 5, delay = 5.second)
+        }
+      }
   }
 
   def copyFile(

--- a/discover-publish/src/main/scala/com/pennsieve/publish/PackagesExport.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/PackagesExport.scala
@@ -91,6 +91,10 @@ object PackagesExport extends LazyLogging {
         currentPackageFileList
       )
 
+      _ = fileActions.foreach(
+        fa => logger.info(s"exportPackageSources5x() fileAction: ${fa}")
+      )
+
       // Write FileActionList to S3 (will be used by Cleanup Job on failure)
       fileActionListUpload = Storage.uploadToS3(
         container,

--- a/discover-publish/src/main/scala/com/pennsieve/publish/PackagesExport.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/PackagesExport.scala
@@ -89,11 +89,10 @@ object PackagesExport extends LazyLogging {
         previousFileManifests,
         currentFileManifests,
         currentPackageFileList
-      )
-
-      _ = fileActions.foreach(
-        fa => logger.info(s"exportPackageSources5x() fileAction: ${fa}")
-      )
+      ).map { fileAction =>
+        logger.info(s"exportPackageSources5x() fileAction: ${fileAction}")
+        fileAction
+      }
 
       // Write FileActionList to S3 (will be used by Cleanup Job on failure)
       fileActionListUpload = Storage.uploadToS3(

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -144,6 +144,9 @@ object Publish extends StrictLogging {
       // filter out where sourcePackageId.isEmpty because these are Files not attached to Packages
       // (i.e., readme.md, banner.jpg, changelog.md, the manifest.json, and Model export files)
       previousFiles = metadata.files.filterNot(_.sourcePackageId.isEmpty)
+      _ = previousFiles.foreach(
+        pf => logger.info(s"publishAssets5x() previousFile: ${pf}")
+      )
 
       // get current set of Packages, and copy to Discover S3
       packagesResult <- PackagesExport

--- a/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/Publish.scala
@@ -143,10 +143,11 @@ object Publish extends StrictLogging {
 
       // filter out where sourcePackageId.isEmpty because these are Files not attached to Packages
       // (i.e., readme.md, banner.jpg, changelog.md, the manifest.json, and Model export files)
-      previousFiles = metadata.files.filterNot(_.sourcePackageId.isEmpty)
-      _ = previousFiles.foreach(
-        pf => logger.info(s"publishAssets5x() previousFile: ${pf}")
-      )
+      previousFiles = metadata.files.filterNot(_.sourcePackageId.isEmpty).map {
+        previousFile =>
+          logger.info(s"publishAssets5x() previousFile: ${previousFile}")
+          previousFile
+      }
 
       // get current set of Packages, and copy to Discover S3
       packagesResult <- PackagesExport

--- a/discover-publish/src/main/scala/com/pennsieve/publish/models/CopyAction.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/models/CopyAction.scala
@@ -126,7 +126,9 @@ object FileActionList extends LazyLogging {
             versionId = deleteAction.s3VersionId
           )
       }
-      logger.info(s"FileActionList.from() fileActionItem: ${fileActionItem}")
+      logger.info(
+        s"FileActionList.from() fileAction: ${fileAction} -> fileActionItem: ${fileActionItem}"
+      )
       fileActionItem
     })
 

--- a/discover-publish/src/main/scala/com/pennsieve/publish/models/CopyAction.scala
+++ b/discover-publish/src/main/scala/com/pennsieve/publish/models/CopyAction.scala
@@ -24,6 +24,7 @@ import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 
 import scala.collection.immutable
+import com.typesafe.scalalogging.LazyLogging
 
 sealed trait FileAction {
   def fileKey: String
@@ -93,7 +94,7 @@ object FileActionItem {
 
 case class FileActionList(fileActionList: Seq[FileActionItem])
 
-object FileActionList {
+object FileActionList extends LazyLogging {
   def path(prefix: String, suffix: String): String =
     prefix.endsWith("/") match {
       case true => s"${prefix}${suffix}"
@@ -102,7 +103,7 @@ object FileActionList {
 
   def from(fileActions: Seq[FileAction]): FileActionList =
     new FileActionList(fileActionList = fileActions.map { fileAction =>
-      fileAction match {
+      val fileActionItem = fileAction match {
         case copyAction: CopyAction =>
           FileActionItem(
             action = FileActionType.CopyFile,
@@ -125,6 +126,8 @@ object FileActionList {
             versionId = deleteAction.s3VersionId
           )
       }
+      logger.info(s"FileActionList.from() fileActionItem: ${fileActionItem}")
+      fileActionItem
     })
 
   implicit val encoder: Encoder[FileActionList] = deriveEncoder[FileActionList]

--- a/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/TestPublish.scala
@@ -1410,7 +1410,424 @@ class TestPublish
 
   }
 
-  "build "
+//  "get dataset metadata" should {
+//    "load manifest.json into DatasetMetadata" in {
+//
+//    }
+//  }
+
+  "decode Manifest in Publishing 5.0 into DatasetMetadata" should {
+    "load manifest.json into a DatasetMetadata 4.0 when there are no S3 Version Ids" in {
+      val sampleMetadataV4 =
+        """{
+        "pennsieveDatasetId": 1,
+        "version": 1,
+        "revision": 1,
+        "name" : "Test Dataset",
+        "description" : "Lorem ipsum",
+        "creator" : { "first_name": "Blaise", "last_name": "Pascal", "orcid": "0000-0009-1234-5678"},
+        "contributors" : [  { "first_name": "Isaac", "last_name": "Newton"}, { "first_name": "Albert", "last_name": "Einstein"}],
+        "sourceOrganization" : "1",
+        "keywords" : [
+        "neuro",
+        "neuron"
+        ],
+        "datePublished": "2019-06-05",
+        "license": "MIT",
+        "@id": "10.21397/jlt1-xdqn",
+        "publisher" : "The University of Pennsylvania",
+        "@context" : "http://purl.org/dc/terms",
+        "@type":"Dataset",
+        "schemaVersion": "http://schema.org/version/3.7/",
+        "collections" : [
+          {
+            "name" : "My great collection"
+          }
+        ],
+        "relatedPublications" : [
+          {
+            "doi" : "10.26275/t6j6-77pu",
+            "relationshipType" : "IsDescribedBy"
+          }
+        ],
+        "files" : [
+          {
+            "path" : "packages/brain.dcm",
+            "size" : 15010,
+            "fileType" : "DICOM",
+            "sourcePackageId" : "N:package:1"
+          }
+        ],
+        "pennsieveSchemaVersion" : "4.0"
+        }"""
+
+      val mdV4 = DatasetMetadataV4_0(
+        pennsieveDatasetId = 1,
+        version = 1,
+        revision = Some(1),
+        name = "Test Dataset",
+        description = "Lorem ipsum",
+        creator =
+          PublishedContributor("Blaise", "Pascal", Some("0000-0009-1234-5678")),
+        contributors = List(
+          PublishedContributor("Isaac", "Newton", None),
+          PublishedContributor("Albert", "Einstein", None)
+        ),
+        sourceOrganization = "1",
+        keywords = List("neuro", "neuron"),
+        datePublished = LocalDate.of(2019, 6, 5),
+        license = Some(License.MIT),
+        `@id` = "10.21397/jlt1-xdqn",
+        `@context` = "http://purl.org/dc/terms",
+        files = List(
+          FileManifest(
+            "packages/brain.dcm",
+            15010,
+            FileType.DICOM,
+            Some("N:package:1")
+          )
+        ),
+        collections = Some(List(PublishedCollection("My great collection"))),
+        relatedPublications = Some(
+          List(
+            PublishedExternalPublication(
+              Doi("10.26275/t6j6-77pu"),
+              Some(RelationshipType.IsDescribedBy)
+            )
+          )
+        )
+      )
+
+      decode[DatasetMetadata](sampleMetadataV4) shouldBe Right(mdV4)
+    }
+
+    "load manifest.json into a DatasetMetadata 4.0 when there are S3 Version Ids" in {
+      val sampleMetadataV4 =
+        """{
+        "pennsieveDatasetId": 1,
+        "version": 1,
+        "revision": 1,
+        "name" : "Test Dataset",
+        "description" : "Lorem ipsum",
+        "creator" : { "first_name": "Blaise", "last_name": "Pascal", "orcid": "0000-0009-1234-5678"},
+        "contributors" : [  { "first_name": "Isaac", "last_name": "Newton"}, { "first_name": "Albert", "last_name": "Einstein"}],
+        "sourceOrganization" : "1",
+        "keywords" : [
+        "neuro",
+        "neuron"
+        ],
+        "datePublished": "2019-06-05",
+        "license": "MIT",
+        "@id": "10.21397/jlt1-xdqn",
+        "publisher" : "The University of Pennsylvania",
+        "@context" : "http://purl.org/dc/terms",
+        "@type":"Dataset",
+        "schemaVersion": "http://schema.org/version/3.7/",
+        "collections" : [
+          {
+            "name" : "My great collection"
+          }
+        ],
+        "relatedPublications" : [
+          {
+            "doi" : "10.26275/t6j6-77pu",
+            "relationshipType" : "IsDescribedBy"
+          }
+        ],
+        "files" : [
+          {
+            "path" : "packages/brain.dcm",
+            "size" : 15010,
+            "fileType" : "DICOM",
+            "sourcePackageId" : "N:package:1",
+            "s3VersionId": "s3-version-abc123"
+          }
+        ],
+        "pennsieveSchemaVersion" : "4.0"
+        }"""
+
+      val mdV4 = DatasetMetadataV4_0(
+        pennsieveDatasetId = 1,
+        version = 1,
+        revision = Some(1),
+        name = "Test Dataset",
+        description = "Lorem ipsum",
+        creator =
+          PublishedContributor("Blaise", "Pascal", Some("0000-0009-1234-5678")),
+        contributors = List(
+          PublishedContributor("Isaac", "Newton", None),
+          PublishedContributor("Albert", "Einstein", None)
+        ),
+        sourceOrganization = "1",
+        keywords = List("neuro", "neuron"),
+        datePublished = LocalDate.of(2019, 6, 5),
+        license = Some(License.MIT),
+        `@id` = "10.21397/jlt1-xdqn",
+        `@context` = "http://purl.org/dc/terms",
+        files = List(
+          FileManifest(
+            "packages/brain.dcm",
+            15010,
+            FileType.DICOM,
+            Some("N:package:1"),
+            Some("s3-version-abc123")
+          )
+        ),
+        collections = Some(List(PublishedCollection("My great collection"))),
+        relatedPublications = Some(
+          List(
+            PublishedExternalPublication(
+              Doi("10.26275/t6j6-77pu"),
+              Some(RelationshipType.IsDescribedBy)
+            )
+          )
+        )
+      )
+
+      decode[DatasetMetadata](sampleMetadataV4) shouldBe Right(mdV4)
+    }
+
+    "load manifest.json into a DatasetMetadata 4.0 with and without files having S3 Version Ids" in {
+      val sampleMetadataV4 =
+        """{
+        "pennsieveDatasetId": 1,
+        "version": 1,
+        "revision": 1,
+        "name" : "Test Dataset",
+        "description" : "Lorem ipsum",
+        "creator" : { "first_name": "Blaise", "last_name": "Pascal", "orcid": "0000-0009-1234-5678"},
+        "contributors" : [  { "first_name": "Isaac", "last_name": "Newton"}, { "first_name": "Albert", "last_name": "Einstein"}],
+        "sourceOrganization" : "1",
+        "keywords" : [
+        "neuro",
+        "neuron"
+        ],
+        "datePublished": "2019-06-05",
+        "license": "MIT",
+        "@id": "10.21397/jlt1-xdqn",
+        "publisher" : "The University of Pennsylvania",
+        "@context" : "http://purl.org/dc/terms",
+        "@type":"Dataset",
+        "schemaVersion": "http://schema.org/version/3.7/",
+        "collections" : [
+          {
+            "name" : "My great collection"
+          }
+        ],
+        "relatedPublications" : [
+          {
+            "doi" : "10.26275/t6j6-77pu",
+            "relationshipType" : "IsDescribedBy"
+          }
+        ],
+        "files" : [
+          {
+            "name" : "manifest.json",
+            "path" : "manifest.json",
+            "size" : 1234,
+            "fileType" : "Json"
+          },
+          {
+            "path" : "packages/brain.dcm",
+            "size" : 15010,
+            "fileType" : "DICOM",
+            "sourcePackageId" : "N:package:1",
+            "s3VersionId": "s3-version-abc123"
+          }
+        ],
+        "pennsieveSchemaVersion" : "4.0"
+        }"""
+
+      val mdV4 = DatasetMetadataV4_0(
+        pennsieveDatasetId = 1,
+        version = 1,
+        revision = Some(1),
+        name = "Test Dataset",
+        description = "Lorem ipsum",
+        creator =
+          PublishedContributor("Blaise", "Pascal", Some("0000-0009-1234-5678")),
+        contributors = List(
+          PublishedContributor("Isaac", "Newton", None),
+          PublishedContributor("Albert", "Einstein", None)
+        ),
+        sourceOrganization = "1",
+        keywords = List("neuro", "neuron"),
+        datePublished = LocalDate.of(2019, 6, 5),
+        license = Some(License.MIT),
+        `@id` = "10.21397/jlt1-xdqn",
+        `@context` = "http://purl.org/dc/terms",
+        files = List(
+          FileManifest("manifest.json", "manifest.json", 1234, FileType.Json),
+          FileManifest(
+            "packages/brain.dcm",
+            15010,
+            FileType.DICOM,
+            Some("N:package:1"),
+            Some("s3-version-abc123")
+          )
+        ),
+        collections = Some(List(PublishedCollection("My great collection"))),
+        relatedPublications = Some(
+          List(
+            PublishedExternalPublication(
+              Doi("10.26275/t6j6-77pu"),
+              Some(RelationshipType.IsDescribedBy)
+            )
+          )
+        )
+      )
+
+      decode[DatasetMetadata](sampleMetadataV4) shouldBe Right(mdV4)
+    }
+
+//    "load an actual manifest.json into a DatasetMetadata 4.0" in {
+//      val sampleMetadataV4 =
+//        """{
+//          |  "pennsieveDatasetId" : 5068,
+//          |  "version" : 1,
+//          |  "name" : "publishing-5x-8",
+//          |  "description" : "test dataset 8",
+//          |  "creator" : {
+//          |    "first_name" : "Michael",
+//          |    "last_name" : "Uftring",
+//          |    "orcid" : "0000-0001-7054-4685"
+//          |  },
+//          |  "contributors" : [
+//          |    {
+//          |      "first_name" : "Michael",
+//          |      "last_name" : "Uftring",
+//          |      "orcid" : "0000-0001-7054-4685"
+//          |    }
+//          |  ],
+//          |  "sourceOrganization" : "Publishing 5.0 Workspace",
+//          |  "keywords" : [
+//          |    "publishing",
+//          |    "5.0"
+//          |  ],
+//          |  "datePublished" : "2023-09-11",
+//          |  "license" : "Community Data License Agreement – Permissive",
+//          |  "@id" : "https://doi.org/10.21397/hsvc-wubl",
+//          |  "publisher" : "The University of Pennsylvania",
+//          |  "@context" : "http://schema.org/",
+//          |  "@type" : "Dataset",
+//          |  "schemaVersion" : "http://schema.org/version/3.7/",
+//          |  "collections" : [
+//          |  ],
+//          |  "relatedPublications" : [
+//          |  ],
+//          |  "files" : [
+//          |    {
+//          |      "name" : "banner.jpg",
+//          |      "path" : "banner.jpg",
+//          |      "size" : 5008,
+//          |      "fileType" : "JPEG",
+//          |      "s3VersionId" : "9u.qGGC5BgkxZhTv4VlvhnSHR8_yK.zs"
+//          |    },
+//          |    {
+//          |      "name" : "changelog.md",
+//          |      "path" : "changelog.md",
+//          |      "size" : 24,
+//          |      "fileType" : "Markdown",
+//          |      "s3VersionId" : "llW9Nah2l2JyqylZ6mQW_GwsFjAM1TeT"
+//          |    },
+//          |    {
+//          |      "name" : "file.csv",
+//          |      "path" : "metadata/records/file.csv",
+//          |      "size" : 355,
+//          |      "fileType" : "CSV",
+//          |      "s3VersionId" : "4TLWZysTwpqi5JQkZw4VRMnJlMO7umQh"
+//          |    },
+//          |    {
+//          |      "name" : "manifest.json",
+//          |      "path" : "manifest.json",
+//          |      "size" : 2741,
+//          |      "fileType" : "Json"
+//          |    },
+//          |    {
+//          |      "name" : "readme.md",
+//          |      "path" : "readme.md",
+//          |      "size" : 25,
+//          |      "fileType" : "Markdown",
+//          |      "s3VersionId" : "x16k1IhceSfRU5KcUUmzEMhZG533sI0I"
+//          |    },
+//          |    {
+//          |      "name" : "schema.json",
+//          |      "path" : "metadata/schema.json",
+//          |      "size" : 567,
+//          |      "fileType" : "Json",
+//          |      "s3VersionId" : "5Tiv4AcFDueHJheHibe.XxZDglRnMixq"
+//          |    },
+//          |    {
+//          |      "name" : "test-001.dat",
+//          |      "path" : "files/first/test-001.dat",
+//          |      "size" : 4100,
+//          |      "fileType" : "Persyst",
+//          |      "sourcePackageId" : "N:package:a6512ea3-918d-45cd-adef-a5ef8f30600e",
+//          |      "s3VersionId" : "L6jMEVVz7.jKms05YP.2DlV_7KjxzFf1"
+//          |    },
+//          |    {
+//          |      "name" : "test-002.dat",
+//          |      "path" : "files/first/test-002.dat",
+//          |      "size" : 4100,
+//          |      "fileType" : "Persyst",
+//          |      "sourcePackageId" : "N:package:929564cc-9260-41d8-857f-cc78f90eb8ca",
+//          |      "s3VersionId" : "vlutn_m4ZOECZKhpMhaeYtFceHCWHQD7"
+//          |    },
+//          |    {
+//          |      "name" : "test-003.dat",
+//          |      "path" : "files/first/test-003.dat",
+//          |      "size" : 4100,
+//          |      "fileType" : "Persyst",
+//          |      "sourcePackageId" : "N:package:9bf150bc-c700-4094-a3d0-1e43d22f971d",
+//          |      "s3VersionId" : "IFmDw_6sNP_b9Rx0LTjvx4EasTvYjcY6"
+//          |    }
+//          |  ],
+//          |  "pennsieveSchemaVersion" : "4.0"
+//          |}""".stripMargin
+//
+//      val mdV4 = DatasetMetadataV4_0(
+//        pennsieveDatasetId = 1,
+//        version = 1,
+//        revision = Some(1),
+//        name = "Test Dataset",
+//        description = "Lorem ipsum",
+//        creator =
+//          PublishedContributor("Blaise", "Pascal", Some("0000-0009-1234-5678")),
+//        contributors = List(
+//          PublishedContributor("Isaac", "Newton", None),
+//          PublishedContributor("Albert", "Einstein", None)
+//        ),
+//        sourceOrganization = "1",
+//        keywords = List("neuro", "neuron"),
+//        datePublished = LocalDate.of(2019, 6, 5),
+//        license = Some(License.MIT),
+//        `@id` = "10.21397/jlt1-xdqn",
+//        `@context` = "http://purl.org/dc/terms",
+//        files = List(
+//          FileManifest("manifest.json", "manifest.json", 1234, FileType.Json),
+//          FileManifest(
+//            "packages/brain.dcm",
+//            15010,
+//            FileType.DICOM,
+//            Some("N:package:1"),
+//            Some("s3-version-abc123")
+//          )
+//        ),
+//        collections = Some(List(PublishedCollection("My great collection"))),
+//        relatedPublications = Some(
+//          List(
+//            PublishedExternalPublication(
+//              Doi("10.26275/t6j6-77pu"),
+//              Some(RelationshipType.IsDescribedBy)
+//            )
+//          )
+//        )
+//      )
+//
+//      decode[DatasetMetadata](sampleMetadataV4) shouldBe Right(mdV4)
+//    }
+
+  }
 
   /**
     * Delete all objects from bucket, and delete the bucket itself


### PR DESCRIPTION
## Changes Proposed

- added some logging to track file actions (copy, keep, delete)
- debugging "lost" S3 Version Ids in File Actions intermediate output file

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
