### PR TITLE
Update GET User endpoint to include ORCID authorization

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/UserController.scala
+++ b/api/src/main/scala/com/pennsieve/api/UserController.scala
@@ -603,7 +603,12 @@ class UserController(
 
         updatedUser = loggedInUser.copy(orcidAuthorization = Some(orcidAuth))
         _ <- secureContainer.userManager.update(updatedUser).orError()
-      } yield OrcidDTO(name = orcidAuth.name, orcid = orcidAuth.orcid)
+      } yield
+        OrcidDTO(
+          name = orcidAuth.name,
+          orcid = orcidAuth.orcid,
+          scope = orcidAuth.scope.split(" ").toList
+        )
 
       val is = result.value.map(
         either =>

--- a/api/src/main/scala/com/pennsieve/api/UserController.scala
+++ b/api/src/main/scala/com/pennsieve/api/UserController.scala
@@ -603,12 +603,7 @@ class UserController(
 
         updatedUser = loggedInUser.copy(orcidAuthorization = Some(orcidAuth))
         _ <- secureContainer.userManager.update(updatedUser).orError()
-      } yield
-        OrcidDTO(
-          name = orcidAuth.name,
-          orcid = orcidAuth.orcid,
-          scope = orcidAuth.scope.split(" ").toList
-        )
+      } yield Builders.orcidDTO(orcidAuth)
 
       val is = result.value.map(
         either =>

--- a/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
@@ -24,7 +24,8 @@ import com.pennsieve.db.CustomTermsOfService
 import com.pennsieve.dtos.{
   CustomTermsOfServiceDTO,
   OrcidDTO,
-  PennsieveTermsOfServiceDTO
+  PennsieveTermsOfServiceDTO,
+  UserDTO
 }
 import com.pennsieve.helpers.{ MockAuditLogger, OrcidClient }
 import com.pennsieve.models.DBPermission.Delete
@@ -44,7 +45,7 @@ class TestUsersController extends BaseApiTest {
     expiresIn = 100,
     tokenType = "tokenType",
     orcid = "orcid",
-    scope = "scope",
+    scope = "/read-limited /activities/update",
     refreshToken = "refreshToken"
   )
 
@@ -124,6 +125,15 @@ class TestUsersController extends BaseApiTest {
       body should include(loggedInUser.middleInitial.get)
       body should include(loggedInUser.lastName)
       body should include(loggedInUser.degree.get.entryName)
+    }
+  }
+
+  test("get user info includes ORCID Auth Scope") {
+    get(s"", headers = authorizationHeader(loggedInOrcidJwt) ++ traceIdHeader()) {
+      status should equal(200)
+      val result: UserDTO = parsedBody.extract[UserDTO]
+      val orcidDto = result.orcid.get
+      orcidDto.scope.length shouldBe (2)
     }
   }
 

--- a/core-models/src/main/scala/com/pennsieve/dtos/OrcidDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/OrcidDTO.scala
@@ -19,7 +19,7 @@ package com.pennsieve.dtos
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
 import io.circe.{ Decoder, Encoder }
 
-case class OrcidDTO(name: String, orcid: String)
+case class OrcidDTO(name: String, orcid: String, scope: List[String])
 object OrcidDTO {
   implicit val encoder: Encoder[OrcidDTO] = deriveEncoder[OrcidDTO]
   implicit val decoder: Decoder[OrcidDTO] = deriveDecoder[OrcidDTO]

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -680,7 +680,12 @@ object Builders {
 
   def orcidDTO(user: User): Option[OrcidDTO] = {
     user.orcidAuthorization.map(
-      orcidAuth => OrcidDTO(name = orcidAuth.name, orcid = orcidAuth.orcid)
+      orcidAuth =>
+        OrcidDTO(
+          name = orcidAuth.name,
+          orcid = orcidAuth.orcid,
+          scope = orcidAuth.scope.split(" ").toList
+        )
     )
   }
 

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -49,6 +49,7 @@ import com.pennsieve.models.{
   FeatureFlag,
   File,
   FileObjectType,
+  OrcidAuthorization,
   Organization,
   Package,
   PackageType,
@@ -678,16 +679,14 @@ object Builders {
 
   }
 
-  def orcidDTO(user: User): Option[OrcidDTO] = {
-    user.orcidAuthorization.map(
-      orcidAuth =>
-        OrcidDTO(
-          name = orcidAuth.name,
-          orcid = orcidAuth.orcid,
-          scope = orcidAuth.scope.split(" ").toList
-        )
-    )
-  }
+  def orcidDTO(user: User): Option[OrcidDTO] =
+    user.orcidAuthorization.map(orcidAuth => orcidDTO(orcidAuth))
+
+  def orcidDTO(orcidAuth: OrcidAuthorization): OrcidDTO = OrcidDTO(
+    name = orcidAuth.name,
+    orcid = orcidAuth.orcid,
+    scope = orcidAuth.scope.split(" ").toList
+  )
 
   def userDTO(
     user: User,


### PR DESCRIPTION
## Changes Proposed

In support of [DAT Y7 4.2 M: Push published dataset info to Pennsieve user's (not external contributor’s) ORCID account](https://app.clickup.com/t/u5d7x0), this completes the [Update GET User endpoint to include ORCID authorization](https://app.clickup.com/t/868692wzb) task.

The ORCID DTO that is included in the User DTO returned by the GET User API endpoint has been expanded to include a list of scopes that the user has authorized. The request for authorization is made by the Pennsieve App, which opens a browser window at ORCID where authentication and authorization are performed. The Pennsieve App captures the authorization response from ORCID and invokes the API endpoint to store the user's ORCID Authorization.

```
case class OrcidDTO(
    name: String, 
    orcid: String, 
    scope: List[String]
)
```

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
