### PR TITLE
DAT Y7 3.1 M: Update the Pennsieve Backend to support multiple dataset types

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/Dataset.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/Dataset.scala
@@ -33,6 +33,8 @@ object DatasetType extends Enum[DatasetType] with CirceEnum[DatasetType] {
 
   case object Research extends DatasetType
   case object Trial extends DatasetType
+  case object Collection extends DatasetType
+  case object Release extends DatasetType
 }
 
 final case class Dataset(

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20231107115359__create_tables_for_dataset_types.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20231107115359__create_tables_for_dataset_types.sql
@@ -1,15 +1,17 @@
-CREATE TABLE dataset_collections
+CREATE TABLE dataset_reference
 (
     id SERIAL PRIMARY KEY,
     dataset_id INTEGER NOT NULL references datasets(id) ON DELETE CASCADE,
-    dataset_order INTEGER,
+    reference_order INTEGER,
     reference_type VARCHAR(255) NOT NULL,
     reference_id VARCHAR(255) NOT NULL,
+    properties JSONB NOT NULL DEFAULT '[]',
+    tags VARCHAR(255) ARRAY NOT NULL DEFAULT '{}',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TRIGGER dataset_collections_update_updated_at BEFORE UPDATE ON dataset_collections FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+CREATE TRIGGER dataset_reference_update_updated_at BEFORE UPDATE ON dataset_reference FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
 
 CREATE TABLE dataset_release
 (

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20231107115359__create_tables_for_dataset_types.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20231107115359__create_tables_for_dataset_types.sql
@@ -21,7 +21,7 @@ CREATE TABLE dataset_release
     url VARCHAR(255) NOT NULL,
     label VARCHAR(255) NOT NULL,
     marker VARCHAR(255) NOT NULL,
-    date TIMESTAMP NOT NULL,
+    release_date TIMESTAMP NOT NULL,
     properties JSONB NOT NULL DEFAULT '[]',
     tags VARCHAR(255) ARRAY NOT NULL DEFAULT '{}',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20231107115359__create_tables_for_dataset_types.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20231107115359__create_tables_for_dataset_types.sql
@@ -1,0 +1,29 @@
+CREATE TABLE dataset_collections
+(
+    id SERIAL PRIMARY KEY,
+    dataset_id INTEGER NOT NULL references datasets(id) ON DELETE CASCADE,
+    dataset_order INTEGER,
+    reference_type VARCHAR(255) NOT NULL,
+    reference_id VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER dataset_collections_update_updated_at BEFORE UPDATE ON dataset_collections FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+CREATE TABLE dataset_release
+(
+    id SERIAL PRIMARY KEY,
+    dataset_id INTEGER NOT NULL references datasets(id) ON DELETE CASCADE,
+    origin VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    label VARCHAR(255) NOT NULL,
+    marker VARCHAR(255) NOT NULL,
+    date TIMESTAMP NOT NULL,
+    properties JSONB NOT NULL DEFAULT '[]',
+    tags VARCHAR(255) ARRAY NOT NULL DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER dataset_release_update_updated_at BEFORE UPDATE ON dataset_release FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();


### PR DESCRIPTION
## Changes Proposed

In support of [DAT Y7 3.1 M: Update the Pennsieve Backend to support multiple dataset types](https://app.clickup.com/t/8685k5tve), and documented in [3.1 M: Update the Pennsieve Backend to support multiple dataset types](https://app.clickup.com/8664796/v/dc/88dpw-4171/88dpw-8291).

Adding the concept of two new dataset types:
- `Collection`: *Collection datasets contain a list of DOIs to other datasets as the primary data type*
- `Release`: *GitHub release datasets contain a link to a specific release of a public GitHub repository*

Types defined, and database tables created (see code).
```
object DatasetType extends Enum[DatasetType] with CirceEnum[DatasetType] {
  val values: IndexedSeq[DatasetType] = findValues

  case object Research extends DatasetType
  case object Trial extends DatasetType
  case object Collection extends DatasetType
  case object Release extends DatasetType
}
```

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
