### PR TITLE
fix for linking ORCID iD to Pennsieve account

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/UserController.scala
+++ b/api/src/main/scala/com/pennsieve/api/UserController.scala
@@ -38,6 +38,7 @@ import com.pennsieve.models.{
   CognitoId,
   DateVersion,
   Degree,
+  OrcidAuthorization,
   OrcidIdentityProvider,
   User
 }
@@ -70,7 +71,8 @@ case class UserMergeRequest(
 
 case class UpdatePennsieveTermsOfServiceRequest(version: String)
 
-case class ORCIDRequest(authorizationCode: String)
+case class ORCIDAuthorizationInfo(source: String, code: String)
+case class ORCIDRequest(authorizationCode: ORCIDAuthorizationInfo)
 
 // `version` expected to be a date in the same format as DateVersion:
 case class AcceptCustomTermsOfServiceRequest(version: String)
@@ -598,7 +600,7 @@ class UserController(
           ).toEitherT[Future]
 
         orcidAuth <- EitherT.right[ActionResult](
-          orcidClient.getToken(orcidRequest.authorizationCode)
+          orcidClient.getToken(orcidRequest.authorizationCode.code)
         )
 
         updatedUser = loggedInUser.copy(orcidAuthorization = Some(orcidAuth))

--- a/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
@@ -336,7 +336,14 @@ class TestUsersController extends BaseApiTest {
   }
 
   test("orcid creation") {
-    val orcidRequest = write(ORCIDRequest(testAuthorizationCode))
+    val orcidRequest = write(
+      ORCIDRequest(
+        ORCIDAuthorizationInfo(
+          source = "orcid-redirect-response",
+          code = testAuthorizationCode
+        )
+      )
+    )
 
     postJson(
       s"/orcid",
@@ -351,7 +358,14 @@ class TestUsersController extends BaseApiTest {
   }
 
   test("orcid deletion") {
-    val orcidRequest = write(ORCIDRequest(testAuthorizationCode))
+    val orcidRequest = write(
+      ORCIDRequest(
+        ORCIDAuthorizationInfo(
+          source = "orcid-redirect-response",
+          code = testAuthorizationCode
+        )
+      )
+    )
     postJson(
       s"/orcid",
       orcidRequest,


### PR DESCRIPTION
## Changes Proposed

When a user attempts to link their ORCID iD to their Pennsieve account, the API rejects the request with the message:

```
No usable value for authorizationCode Do not know how to convert JObject(List((source,JString(orcid-redirect-response)), (code,JString(U4Tgos)))) into class java.lang.String
``` 

The Pennsieve App is sending this:

```json
{
  "authorizationCode": {
    "source": "orcid-redirect-response",
    "code": "9GoLMU"
  }
}
```

The fix involves changing the Scala case classes to map the JSON data to this:

```scala
case class ORCIDAuthorizationInfo(source: String, code: String)
case class ORCIDRequest(authorizationCode: ORCIDAuthorizationInfo)
```

There are two unit tests that check:
1. linking an ORCID iD from a Pennsieve account
2. unlinking an ORCID iD from a Pennsieve account

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
