### PR TITLE
Update discover-publish config settings

### DIFF
--- a/discover-publish/src/main/resources/application.conf
+++ b/discover-publish/src/main/resources/application.conf
@@ -29,7 +29,7 @@ s3 {
   asset-key-prefix = ${?S3_ASSET_KEY_PREFIX}
   region = "us-east-1"
   region = ${?S3_REGION}
-  copy-chunk-size = 5000000000  # 5Gb (max allowed)
+  copy-chunk-size = 4294967296  # 4Gib (max that will fit into an Int)
   copy-chunk-size = ${?S3_COPY_CHUNK_SIZE}
   copy-chunk-parallelism = 1
   copy-file-parallelism = 8

--- a/discover-publish/src/main/resources/application.conf
+++ b/discover-publish/src/main/resources/application.conf
@@ -31,8 +31,8 @@ s3 {
   region = ${?S3_REGION}
   copy-chunk-size = 4294967296  # 4Gib (max that will fit into an Int)
   copy-chunk-size = ${?S3_COPY_CHUNK_SIZE}
-  copy-chunk-parallelism = 1
-  copy-file-parallelism = 8
+  copy-chunk-parallelism = 8
+  copy-file-parallelism = 4
 }
 
 alpakka.s3 {
@@ -55,7 +55,7 @@ akka.http {
 
     # Increase connection limit per-host since all requests will go to S3.  This
     # should be approximately copy-file-parallelism * copy-chunk-parallelism.
-    max-connections = 16
+    max-connections = 32
 
     # Cap number of *buffered* requests waiting for a connection, per-pool. See
     # [1] for a good description of the behavior or `max-open-requests` and
@@ -65,12 +65,19 @@ akka.http {
     #
     # [1] https://www.gregbeech.com/2018/04/08/akka-http-client-pooling-and-parallelism/
     # [2] https://github.com/akka/akka-http/blob/997f01ad72b5560df3b1a3d5a305eba333987d30/akka-http-core/src/main/scala/akka/http/impl/engine/client/PoolInterface.scala#L71-L75
-    max-open-requests = 128
+    max-open-requests = 256
 
    # Some additional links for context on entity subscription and pool problems:
    #
    # https://github.com/akka/akka-http/issues/2120
    # https://github.com/akka/alpakka/issues/2296
    # https://github.com/akka/akka-http/issues/3134
+  }
+  client {
+    # changed from default to reduce the chances of getting akka.stream.SubscriptionWithCancelException$NoMoreElementsNeeded$
+    # errors during multipart copy of large files during publish.
+    #
+    # Suggested here: https://discuss.lightbend.com/t/about-nomoreelementsneeded-exception/8599
+    stream-cancellation-delay = 1 second
   }
 }

--- a/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
@@ -233,7 +233,7 @@ class CopyFlowIntegrationTest
       val targetKeyPrefix = "large-file-test"
 
       val copyActions =
-        makeCopyActions(9, sourceS3Key2, sourceS3Key2, targetKeyPrefix)
+        makeCopyActions(9, sourceS3Key1, sourceS3Key2, targetKeyPrefix)
 
       Await.result(
         Source(copyActions)
@@ -258,7 +258,7 @@ class CopyFlowIntegrationTest
       val targetKeyPrefix = "large-file-test-5x"
 
       val copyActions =
-        makeCopyActions(9, sourceS3Key2, sourceS3Key2, targetKeyPrefix)
+        makeCopyActions(9, sourceS3Key1, sourceS3Key2, targetKeyPrefix)
 
       Await.result(
         Source(copyActions)

--- a/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
@@ -119,13 +119,8 @@ class CopyFlowIntegrationTest
       .empty()
       .withValue(
         "s3.copy-chunk-size",
-        ConfigValueFactory.fromAnyRef(1073741824) //from terraform
-      )
-      .withValue("s3.copy-file-parallelism", ConfigValueFactory.fromAnyRef(4))
-      .withValue("s3.copy-chunk-parallelism", ConfigValueFactory.fromAnyRef(2))
-      .withValue(
-        "akka.http.client.stream-cancellation-delay",
-        ConfigValueFactory.fromAnyRef("1 second")
+        ConfigValueFactory
+          .fromAnyRef(1073741824) //same value set from terraform in dev/prod
       )
       .withFallback(ConfigFactory.load())
 

--- a/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
+++ b/discover-publish/src/test/scala/com/pennsieve/publish/CopyFlowIntegrationTest.scala
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.publish
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.headers.ByteRange
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+import cats.implicits._
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.pennsieve.aws.s3.S3
+import com.pennsieve.clients.{ DatasetAssetClient, S3DatasetAssetClient }
+import com.pennsieve.models._
+import com.pennsieve.publish.models.CopyAction
+import com.typesafe.config.ConfigValueFactory
+import org.scalatest.Inspectors.forAll
+import com.typesafe.config.{ Config, ConfigFactory }
+import net.ceedubs.ficus.Ficus._
+import org.scalatest.EitherValues._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{ Assertion, BeforeAndAfterAll, BeforeAndAfterEach, Suite }
+
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.jdk.CollectionConverters._
+
+/**
+  * Runs tests of CopyFlow against real buckets in AWS.
+  * Expects several environment variables to be in place:
+  *
+  * AWS_ACCESS_KEY_ID
+  * AWS_SECRET_ACCESS_KEY
+  * AWS_SESSION_TOKEN
+  * These are the credentials of a user/role that can perform the copy from the source bucket to the target bucket.
+  * Easy way to get these is to run `assume-role non-prod admin` in a terminal and then run `env` in that terminal to
+  * get these values.
+  *
+  * SOURCE_BUCKET: the bucket containing the files to be copied
+  * SOURCE_KEY: the key of the file to be copied
+  * TARGET_BUCKET: the destination bucket of the copy.
+  */
+class CopyFlowIntegrationTest
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with ValueHelper {
+  self: Suite =>
+
+  implicit var system: ActorSystem = _
+  implicit var executionContext: ExecutionContext = _
+
+  implicit var s3: S3 = _
+  var sourceBucketName: String = _
+  var targetBucketName: String = _
+  var largeFile100GBS3Key: String = _
+  val testOrganization: Organization = sampleOrganization
+
+  var testDataset: Dataset = _
+  var testUser: User = _
+
+  val owner: PublishedContributor =
+    PublishedContributor(
+      first_name = "Shigeru",
+      middle_initial = None,
+      last_name = "Miyamoto",
+      degree = None,
+      orcid = Some("0000-0001-0221-1986")
+    )
+
+  var config: Config = _
+  var s3CopyChunkSize: Int = _
+  var s3CopyChunkParallelism: Int = _
+  var s3CopyFileParallelism: Int = _
+  var s3Client: AmazonS3 = _
+
+  implicit var publishContainer: PublishContainer = _
+  var embargoContainer: PublishContainer = _
+  var datasetAssetClient: DatasetAssetClient = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    sourceBucketName = sys.env("SOURCE_BUCKET")
+    largeFile100GBS3Key = sys.env("SOURCE_KEY")
+    targetBucketName = sys.env("TARGET_BUCKET")
+    // alpakka-s3 v1.0 can only be configured via Typesafe config passed to the
+    // actor system, or as S3Settings that are attached to every graph
+    // There is no config in test/resources, so the load() below will read the
+    // prod config in main/resources
+    config = ConfigFactory
+      .empty()
+      .withValue(
+        "s3.copy-chunk-size",
+        ConfigValueFactory.fromAnyRef(1073741824) //from terraform
+      )
+      .withValue(
+        "akka.http.client.stream-cancellation-delay",
+        ConfigValueFactory.fromAnyRef("1 second")
+      )
+      .withFallback(ConfigFactory.load())
+
+    system = ActorSystem("discover-publish", config)
+    executionContext = system.dispatcher
+    s3Client = {
+      val clientConfig =
+        new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
+      AmazonS3ClientBuilder
+        .standard()
+        .withPathStyleAccessEnabled(true)
+        .withClientConfiguration(clientConfig)
+        .build()
+    }
+    s3 = new S3(s3Client)
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    datasetAssetClient = new S3DatasetAssetClient(s3, assetBucket)
+
+    s3.headBucket(sourceBucketName).toTry.get
+    s3.headBucket(targetBucketName).isRight shouldBe true
+
+    testUser = newUser()
+    testDataset = newDataset()
+
+    s3CopyChunkSize = config.as[Int]("s3.copy-chunk-size")
+    s3CopyChunkParallelism = config.as[Int]("s3.copy-chunk-parallelism")
+    s3CopyFileParallelism = config.as[Int]("s3.copy-file-parallelism")
+
+    publishContainer = {
+      PublishContainer(
+        config = config,
+        s3 = s3,
+        s3Bucket = publishBucket,
+        s3AssetBucket = assetBucket,
+        s3Key = testKey,
+        s3AssetKeyPrefix = assetKeyPrefix,
+        s3CopyChunkSize = s3CopyChunkSize,
+        s3CopyChunkParallelism = s3CopyChunkParallelism,
+        s3CopyFileParallelism = s3CopyFileParallelism,
+        doi = testDoi,
+        dataset = testDataset,
+        publishedDatasetId = 100,
+        version = 10,
+        organization = testOrganization,
+        user = ownerUser,
+        userOrcid = "0000-0001-0221-1986",
+        datasetRole = Some(Role.Owner),
+        contributors = List(contributor),
+        collections = List(collection),
+        externalPublications = List(externalPublication),
+        datasetAssetClient = datasetAssetClient,
+        workflowId = PublishingWorkflows.Version4
+      )
+    }
+
+    embargoContainer = {
+      PublishContainer(
+        config = config,
+        s3 = s3,
+        s3Bucket = embargoBucket,
+        s3AssetBucket = assetBucket,
+        s3Key = testKey,
+        s3AssetKeyPrefix = assetKeyPrefix,
+        s3CopyChunkSize = s3CopyChunkSize,
+        s3CopyChunkParallelism = s3CopyChunkParallelism,
+        s3CopyFileParallelism = s3CopyFileParallelism,
+        doi = testDoi,
+        dataset = testDataset,
+        publishedDatasetId = 100,
+        version = 10,
+        organization = testOrganization,
+        user = ownerUser,
+        userOrcid = "0000-0001-0221-1986",
+        datasetRole = Some(Role.Owner),
+        contributors = List(contributor),
+        collections = List(collection),
+        externalPublications = List(externalPublication),
+        datasetAssetClient = datasetAssetClient,
+        workflowId = PublishingWorkflows.Version4
+      )
+    }
+
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    publishContainer.db.close()
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+
+  "this test" should {
+
+    "be able to ls the dev storage bucket" in {
+      val summaries = listBucket(sourceBucketName)
+      summaries should not be empty
+    }
+  }
+
+  "copy S3 files sink" should {
+
+    "copy big files" in {
+      val fileName = "random_data_file.bytes"
+      val sourceS3Key = largeFile100GBS3Key
+      val pkg = createPackageObject(
+        testUser,
+        name = fileName,
+        `type` = PackageType.Unsupported
+      )
+      val file = createFileObject(
+        `package` = pkg,
+        name = fileName,
+        s3Bucket = sourceBucketName,
+        s3Key = sourceS3Key,
+        fileType = FileType.Data,
+        objectType = FileObjectType.Source
+      )
+
+      val targetKeyPrefix = "large-file-test"
+      Await.result(
+        Source
+          .single(
+            CopyAction(
+              pkg = pkg,
+              file = file,
+              toBucket = targetBucketName,
+              baseKey = targetKeyPrefix,
+              fileKey = fileName,
+              packageKey = fileName
+            )
+          )
+          .via(CopyS3ObjectsFlow())
+          .toMat(Sink.ignore)(Keep.right)
+          .run(),
+        Duration.Inf
+      )
+
+      s3FilesExistUnderKey(
+        targetBucketName,
+        s"${targetKeyPrefix}/${fileName}",
+        true
+      ) shouldBe true
+
+    }
+
+    "copy several big files" in {
+      val sourceS3Key = largeFile100GBS3Key
+      val targetKeyPrefix = "large-file-test"
+      val targetFileNames = List("random-file1.data", "random-file2.data")
+
+      val copyActions: List[CopyAction] =
+        for {
+          fileName <- targetFileNames
+
+          pkg = createPackageObject(
+            testUser,
+            name = fileName,
+            `type` = PackageType.Unsupported
+          )
+          file = createFileObject(
+            `package` = pkg,
+            name = fileName,
+            s3Bucket = sourceBucketName,
+            s3Key = sourceS3Key,
+            fileType = FileType.Data,
+            objectType = FileObjectType.Source
+          )
+        } yield
+          CopyAction(
+            pkg = pkg,
+            file = file,
+            toBucket = targetBucketName,
+            baseKey = targetKeyPrefix,
+            fileKey = fileName,
+            packageKey = fileName
+          )
+      Await.result(
+        Source(copyActions)
+          .via(CopyS3ObjectsFlow())
+          .toMat(Sink.ignore)(Keep.right)
+          .run(),
+        Duration.Inf
+      )
+
+      forAll(targetFileNames) { fileName =>
+        s3FilesExistUnderKey(
+          targetBucketName,
+          s"${targetKeyPrefix}/${fileName}",
+          true
+        ) shouldBe true
+      }
+    }
+  }
+
+  def listBucket(bucket: String): mutable.Seq[S3ObjectSummary] =
+    s3.client
+      .listObjectsV2(bucket)
+      .getObjectSummaries
+      .asScala
+
+  def createPackageObject(
+    user: User,
+    name: String = generateRandomString(),
+    nodeId: String = NodeCodes.generateId(NodeCodes.packageCode),
+    `type`: PackageType = PackageType.Text,
+    state: PackageState = PackageState.READY,
+    dataset: Dataset = testDataset,
+    parent: Option[Package] = None
+  ): Package = Package(
+    nodeId = nodeId,
+    name = name,
+    `type` = `type`,
+    datasetId = dataset.id,
+    state = state,
+    ownerId = Some(user.id),
+    parentId = parent.map(_.id)
+  )
+
+  def createFileObject(
+    `package`: Package,
+    name: String = generateRandomString(),
+    s3Bucket: String = sourceBucket,
+    s3Key: String = "key/" + generateRandomString() + ".txt",
+    fileType: FileType = FileType.Text,
+    objectType: FileObjectType = FileObjectType.Source,
+    processingState: FileProcessingState = FileProcessingState.Processed,
+    size: Long = 0,
+    uploadedState: Option[FileState] = None
+  ): File =
+    File(
+      `package`.id,
+      name,
+      fileType,
+      s3Bucket,
+      s3Key,
+      objectType,
+      processingState,
+      size,
+      uploadedState = uploadedState
+    )
+
+  def s3FilesExistUnderKey(
+    s3Bucket: String,
+    s3KeyPrefix: String,
+    matchExact: Boolean = false
+  ): Boolean = {
+    val usePrefix = if (matchExact) {
+      s3KeyPrefix
+    } else {
+      if (s3KeyPrefix.endsWith("/")) {
+        s3KeyPrefix
+      } else {
+        s3KeyPrefix + "/"
+      }
+    }
+    s3.client
+      .listObjects(s3Bucket, usePrefix)
+      .getObjectSummaries
+      .size() > 0
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.9.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.11.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 


### PR DESCRIPTION
## Changes Proposed
PR updates several settings in `application.conf` for the discover-publish task to reduce the number of failed publish jobs involving files in the 100s of GB range. 

The specific errors are found in [BUG: Unable to publish terabyte datasets](https://app.clickup.com/t/86869aa8b)

This increases an http stream cancellation delay timeout in Akka as suggested in https://discuss.lightbend.com/t/about-nomoreelementsneeded-exception/8599/5.

The PR also decreases file-parallelism in the CopyObjectFlow to avoid overwhelming the Akka system, when intermittent AWS errors occur. The chunk-parallelism is increased to compensate as is the size of Akka's HTTP client connection pool.

A Scala test file has been added, but as it accesses real S3 buckets, it requires manual configuration and running. It has been configured to be ignored by the automated tests. 

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
