### PR TITLE
fix passing in published dataset id to ORCID registration

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -3502,7 +3502,8 @@ class DataSetsController(
   def registerOrcidWork(
     secureContainer: SecureAPIContainer,
     dataset: Dataset,
-    user: User
+    user: User,
+    publishedDatasetId: Option[Int]
   ): EitherT[Future, CoreError, Option[DatasetRegistration]] = {
     logger.info("registering publication at ORCID")
     for {
@@ -3546,7 +3547,7 @@ class DataSetsController(
             orcidId = orcidAuthorization.orcid,
             accessToken = orcidAuthorization.accessToken,
             orcidPutCode = registrationValue,
-            publishedDatasetId = dataset.id,
+            publishedDatasetId = publishedDatasetId,
             title = dataset.name,
             subTitle = dataset.description.get,
             doi = doi
@@ -3628,7 +3629,12 @@ class DataSetsController(
       registration <- if (completion.success && registrableEvent(
           publicationStatus
         ) && orcidAuthorized(user)) {
-        registerOrcidWork(secureContainer, dataset, user)
+        registerOrcidWork(
+          secureContainer,
+          dataset,
+          user,
+          completion.publishedDatasetId
+        )
       } else {
         Future.successful(None).toEitherT
       }

--- a/api/src/main/scala/com/pennsieve/helpers/OrcidClient.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/OrcidClient.scala
@@ -46,7 +46,7 @@ case class OrcidWorkPublishing(
   orcidId: String,
   accessToken: String,
   orcidPutCode: Option[String],
-  publishedDatasetId: Int,
+  publishedDatasetId: Option[Int],
   title: String,
   subTitle: String,
   doi: Option[String]
@@ -190,10 +190,12 @@ class OrcidClientImpl(
             )
           case None => List.empty[OrcidExternalId]
         }),
-      url = OrcidTitleValue(
-        value =
-          s"https://${orcidClientConfig.discoverAppHost}/datasets/${work.publishedDatasetId}"
-      )
+      url = OrcidTitleValue(value = work.publishedDatasetId match {
+        case Some(publishedDatasetId: Int) =>
+          s"https://${orcidClientConfig.discoverAppHost}/datasets/${publishedDatasetId}"
+        case None =>
+          s"https://${orcidClientConfig.discoverAppHost}"
+      })
     )
 
     logger.info(


### PR DESCRIPTION
## Changes Proposed

- was mistakenly using the dataset's integer `id` to form the Pennsieve Discover URL
- change to use the published dataset's `id` from Discover (it is an `Option[Int]`)
- in the case it is `None` then use the base Pennsieve Discover URL

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
