### PR TITLE
include ORCID 'put-code' in body of update request

### DIFF
--- a/api/src/main/scala/com/pennsieve/helpers/OrcidClient.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/OrcidClient.scala
@@ -195,7 +195,8 @@ class OrcidClientImpl(
           s"https://${orcidClientConfig.discoverAppHost}/datasets/${publishedDatasetId}"
         case None =>
           s"https://${orcidClientConfig.discoverAppHost}"
-      })
+      }),
+      putCode = work.orcidPutCode
     )
 
     logger.info(

--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -9807,7 +9807,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
 
   }
 
-  test("orcid work json encoding") {
+  test("orcid work json encoding - add record") {
     val json =
       """
         |{
@@ -9847,6 +9847,57 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
         )
       ),
       url = OrcidTitleValue(value = "???")
+    )
+
+    val encoded = orcidWork.asJson
+
+    encoded.toString.filterNot(_.isWhitespace) shouldEqual (json.filterNot(
+      _.isWhitespace
+    ))
+  }
+
+  test("orcid work json encoding - update record") {
+    val json =
+      """
+        |{
+        |  "title" : {
+        |    "title" : { "value" : "title" },
+        |    "subtitle" : { "value" : "subtitle" }
+        |  },
+        |  "type" : "data-set",
+        |  "external-ids" : {
+        |    "external-id" : [
+        |      {
+        |        "external-id-type" : "???",
+        |        "external-id-value" : "???",
+        |        "external-id-relationship" : "???",
+        |        "external-id-url" : { "value" : "???" }
+        |      }
+        |    ]
+        |  },
+        |  "url" : { "value" : "???" },
+        |  "put-code" : "1234567"
+        |}
+        |""".stripMargin
+
+    val orcidWork = OrcidWork(
+      title = OrcidTitle(
+        title = OrcidTitleValue(value = "title"),
+        subtitle = OrcidTitleValue(value = "subtitle")
+      ),
+      `type` = "data-set",
+      externalIds = OricdExternalIds(
+        externalId = List(
+          OrcidExternalId(
+            externalIdType = "???",
+            externalIdValue = "???",
+            externalIdUrl = OrcidTitleValue(value = "???"),
+            externalIdRelationship = "???"
+          )
+        )
+      ),
+      url = OrcidTitleValue(value = "???"),
+      putCode = Some("1234567")
     )
 
     val encoded = orcidWork.asJson

--- a/core-models/src/main/scala/com/pennsieve/models/OrcidInterface.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/OrcidInterface.scala
@@ -91,17 +91,22 @@ case class OrcidWork(
   title: OrcidTitle,
   `type`: String,
   externalIds: OricdExternalIds,
-  url: OrcidTitleValue
+  url: OrcidTitleValue,
+  putCode: Option[String] = None
 )
 
 object OrcidWork {
   implicit val encoder: Encoder[OrcidWork] = new Encoder[OrcidWork] {
-    final def apply(a: OrcidWork): Json = Json.obj(
-      ("title", a.title.asJson),
-      ("type", Json.fromString(a.`type`)),
-      ("external-ids", a.externalIds.asJson),
-      ("url", a.url.asJson)
-    )
+    final def apply(a: OrcidWork): Json =
+      Json
+        .obj(
+          ("title", a.title.asJson),
+          ("type", Json.fromString(a.`type`)),
+          ("external-ids", a.externalIds.asJson),
+          ("url", a.url.asJson),
+          ("put-code", a.putCode.asJson)
+        )
+        .dropNullValues
   }
   implicit val decoder: Decoder[OrcidWork] = deriveDecoder[OrcidWork]
 }


### PR DESCRIPTION
## Changes Proposed

Updating a **Work** record through the ORCID REST API requires the *Put Code* (the ORCID record identifier) to also be included in the body of the HTTP PUT request (the *Put Code* is also in the request URL).

- add `putCode` to the `OrcidWork` case class (with default = `None`)
- add JSON encoding of `putCode` to `put-code`
- remove JSON objects with `null` value

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
