### PR TITLE
Verify workflow availablity on name vs s3 key

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -630,7 +630,7 @@ class PackagesController(
           )
 
         hasWorkflow = sources
-          .map(_.s3Key)
+          .map(_.name)
           .map(FileUpload.apply)
           .exists(_.info.hasWorkflow)
 

--- a/api/src/test/scala/com/pennsieve/api/TestPackagesController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestPackagesController.scala
@@ -4063,7 +4063,7 @@ class TestPackagesController
 
     fileManager
       .create(
-        "file",
+        "file.bfts",
         FileType.BFTS,
         pkg,
         "bucket",
@@ -4101,7 +4101,7 @@ class TestPackagesController
 
     val unprocessedSource = fileManager
       .create(
-        "file",
+        "file.bfts",
         FileType.BFTS,
         pkg,
         "bucket",
@@ -4115,7 +4115,7 @@ class TestPackagesController
 
     val processedSource = fileManager
       .create(
-        "file",
+        "file.bfts",
         FileType.BFTS,
         pkg,
         "bucket",


### PR DESCRIPTION
## Changes Proposed
uses the file name instead of the S3Key to get the extension and ultimately check if we have a workflow for said extension.

Previously we were using the S3key, however this won't work with the new upload workflow since S3keys are hashes and don't have extensions. Currently this breaks timeseries processing

Updated current unit tests to have extensions in filenames

## Checklist

- [X] unit tests added and/or verified that tests pass
- [X] I have considered any possible security implications of this change
- [X] I have considered deployment issues.
