### PR TITLE
Fix manifest generation for timeseries processing

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -1063,7 +1063,7 @@ class PackagesController(
     val jobId: UUID = UUID.randomUUID
 
     val fileType =
-      PackagePreview.getFileType(sources.map(_.s3Key).map(FileUpload.apply))
+      PackagePreview.getFileType(sources.map(_.name).map(FileUpload.apply))
 
     for {
       encryptionKey <- utilities


### PR DESCRIPTION
## Changes Proposed
This edit was supposed to go out with the last PR, but didn't.

Uses name instead of s3Key to determine if file can be processed

## Checklist

- [X] unit tests added and/or verified that tests pass
- [X] I have considered any possible security implications of this change
- [X] I have considered deployment issues.
