### PR TITLE
Upgrade RDS CA

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -520,7 +520,7 @@ lazy val etlDataCLISettings = Seq(
         "wget",
         "-qO",
         "/root/.postgresql/root.crt",
-        "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
+        "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
       )
       entryPoint("")
     }

--- a/project/SecureDockerfile.scala
+++ b/project/SecureDockerfile.scala
@@ -10,6 +10,6 @@ abstract class SecureDockerfile(image: String) extends Dockerfile {
     "wget",
     "-qO",
     "/home/pennsieve/.postgresql/root.crt",
-    "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
+    "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
   )
 }


### PR DESCRIPTION
## Changes Proposed
**ClickUp Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

Upgrading the CA we pull down to trust when connecting to our PostgreSQL database using `ssl_mode=verify-ca`. The old CA is set to expire in August 2024 so we will need to upgrade our RDS CA. This change allows us to do that without introducing downtime.

## Testing
Tested locally (from the dev jump box) using the bundled PEM in place of the single expiring certificate.

Did not test with a JDBC connection but hopefully it works the same.


## Checklist
- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
