### PR TITLE
Fetch RDS CA bundle image agnostically

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -501,6 +501,7 @@ lazy val inviteCognitoUserSettings = Seq(
   assembly / assemblyMergeStrategy := defaultMergeStrategy.value
 )
 
+import sbtdocker.Dockerfile
 lazy val etlDataCLISettings = Seq(
   name := "etl-data-cli",
   libraryDependencies ++= Seq("com.github.scopt" %% "scopt" % "3.7.1"),
@@ -510,17 +511,14 @@ lazy val etlDataCLISettings = Seq(
     val script: File = new File("etl-data-cli/etl-data.sh")
     val artifactTargetPath = s"/app/${artifact.name}"
 
-    new SecureDockerfile("pennsieve/base-processor-java-python:6-43b7408") {
-
+    new Dockerfile {
+      from("pennsieve/base-processor-java-python:6-43b7408")
       env("ARTIFACT_TARGET_PATH", artifactTargetPath)
       copy(artifact, artifactTargetPath)
       copy(script, "/app/etl-data")
-      run("mkdir", "-p", "/root/.postgresql")
-      run(
-        "wget",
-        "-qO",
-        "/root/.postgresql/root.crt",
-        "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
+      addRaw(
+        "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+        "/root/.postgresql/root.crt"
       )
       entryPoint("")
     }

--- a/project/SecureDockerfile.scala
+++ b/project/SecureDockerfile.scala
@@ -1,15 +1,17 @@
 import sbtdocker.Dockerfile
 
-/** A dockerfile that contains the AWS root cert in the place where
-  * postgres expects to find it (~/.postgresql/root.crt).
-  */
+// A Dockerfile that contains the AWS RDS CA root certificate
+// Assumes the current user is pennsieve
 abstract class SecureDockerfile(image: String) extends Dockerfile {
+  // Where Postgres (psql/JDBC) expects to find the trusted CA certificate
+  val CA_CERT_LOCATION = "/home/pennsieve/.postgresql/root.crt"
+
   from(image)
-  run("mkdir", "-p", "/home/pennsieve/.postgresql")
-  run(
-    "wget",
-    "-qO",
-    "/home/pennsieve/.postgresql/root.crt",
-    "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
+  addRaw(
+    "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+    CA_CERT_LOCATION,
   )
+  user("root")
+  run("chmod", "+r", CA_CERT_LOCATION)
+  user("pennsieve")
 }


### PR DESCRIPTION
## Changes Proposed
**Clickup Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

`wget` was failing for some of the images with:
```
 wget: error getting response: Connection reset by peer
```

This was likely due to an outdated certificate store on the base image. However, updating the base images led down a rabbit hole of other outdated items including missing base images.

Instead, decided to Use docker's `ADD` command to fetch the CA bundle so that the fetch happened by the machine building the image itself.

Unfortunately `ADD` runs as `root` so I needed to do some `USER` juggling in there as well. The assumption that the `USER` of the `SecureDockerfile` is `pennsieve` was consistent with the existing code which but the `root.crt` in the `pennsieve` home directory.


## Testing
- [x] built all the docker images locally
- [x] went into the images and made sure I could read (`cat`) the `root.crt` file. 

## Checklist
- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
