### PR TITLE
Feature: add integration user to workspace

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/OrganizationsController.scala
@@ -186,6 +186,12 @@ case class UpdateDataUseAgreementRequest(
   isDefault: Option[Boolean] = None
 )
 
+case class CreateOrganizationIntegrationUser(purpose: Option[String])
+case class OrganizationIntegrationUser(
+  user: User,
+  tokenSecret: Option[APITokenSecretDTO]
+)
+
 class OrganizationsController(
   val insecureContainer: InsecureAPIContainer,
   val secureContainerBuilder: SecureContainerBuilderType,
@@ -1715,19 +1721,15 @@ class OrganizationsController(
     }
   }
 
-  case class CreateOrganizationIntegrationUser(purpose: Option[String])
-  case class OrganizationIntegrationUser(
-    user: User,
-    tokenSecret: Option[APITokenSecretDTO]
-  )
   val createOrganizationIntegrationUserOperation
     : OperationBuilder = (apiOperation[OrganizationIntegrationUser](
     "createOrganizationIntegrationUser"
   )
     summary "create an integration user in the organization (internal use only)"
     parameters (
+      pathParam[String]("organizationId").description("Organization ID"),
       bodyParam[CreateOrganizationIntegrationUser]("body")
-    ))
+  ))
   post(
     "/:organizationId/integration-user",
     operation(createOrganizationIntegrationUserOperation)
@@ -1743,6 +1745,7 @@ class OrganizationsController(
           }
 
           secureContainer <- getSecureContainer()
+          organizationId <- paramT[String]("organizationId")
           body <- extractOrErrorT[CreateOrganizationIntegrationUser](parsedBody)
 
           // create the integration user


### PR DESCRIPTION
## Changes Proposed

This is an internal-only endpoint that permits Pennsieve Services to create an Integration User in a workspace. The initial use case: The Application Workflow capability needs to associate an Integration User with a Compute Node so that the workflows and applications have access to the Pennsieve workspace resources (i.e., datasets and their content).

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
