### PR TITLE
Feature/track GitHub repos

### DIFF
--- a/migrations/src/main/resources/db/migrations/V20240603122900__add_external_repositories_table.sql
+++ b/migrations/src/main/resources/db/migrations/V20240603122900__add_external_repositories_table.sql
@@ -1,0 +1,40 @@
+CREATE TABLE external_repositories
+(
+    id SERIAL PRIMARY KEY,
+    repository TEXT NOT NULL,
+    url TEXT NOT NULL,
+    organization_id INTEGER NOT NULL references organizations(id),
+    user_id INTEGER NOT NULL references users(id),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER external_repositories_update_updated_at
+    BEFORE UPDATE ON external_repositories
+    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+CREATE TABLE external_repo_publishing
+(
+    repo_id INTEGER NOT NULL references external_repositories(id) ON DELETE CASCADE,
+    dataset_id INTEGER,
+    status TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER external_repo_publishing_update_updated_at
+    BEFORE UPDATE ON external_repo_publishing
+    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+CREATE TABLE external_repo_appstore
+(
+    repo_id INTEGER NOT NULL references external_repositories(id) ON DELETE CASCADE,
+    application_id UUID,
+    status TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER external_repo_appstore_update_updated_at
+    BEFORE UPDATE ON external_repo_appstore
+    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();

--- a/migrations/src/main/resources/db/migrations/V20240603122900__add_external_repositories_table.sql
+++ b/migrations/src/main/resources/db/migrations/V20240603122900__add_external_repositories_table.sql
@@ -3,38 +3,15 @@ CREATE TABLE external_repositories
     id SERIAL PRIMARY KEY,
     repository TEXT NOT NULL,
     url TEXT NOT NULL,
+    type TEXT NOT NULL,
     organization_id INTEGER NOT NULL references organizations(id),
     user_id INTEGER NOT NULL references users(id),
+    dataset_id INTEGER,
+    application_id UUID,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TRIGGER external_repositories_update_updated_at
     BEFORE UPDATE ON external_repositories
-    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
-
-CREATE TABLE external_repo_publishing
-(
-    repo_id INTEGER NOT NULL references external_repositories(id) ON DELETE CASCADE,
-    dataset_id INTEGER,
-    status TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TRIGGER external_repo_publishing_update_updated_at
-    BEFORE UPDATE ON external_repo_publishing
-    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
-
-CREATE TABLE external_repo_appstore
-(
-    repo_id INTEGER NOT NULL references external_repositories(id) ON DELETE CASCADE,
-    application_id UUID,
-    status TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TRIGGER external_repo_appstore_update_updated_at
-    BEFORE UPDATE ON external_repo_appstore
     FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();


### PR DESCRIPTION
## Changes Proposed

Add database table to store external repositories that a user is requesting Pennsieve to track. Current planned tracking purposes (`type`) are: **dataset** for publication, **application** for build and deploy to App Store. This table is in the `pennsieve` schema to make it visible in the "user space" (not specific to, or within an organization scope).

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
