### PR TITLE
Fix/user orcid linking

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/UserController.scala
+++ b/api/src/main/scala/com/pennsieve/api/UserController.scala
@@ -648,7 +648,7 @@ class UserController(
         _ <- if (loggedInUser.orcidAuthorization.isDefined)
           Right(()).toEitherT[Future]
         else
-          Left(BadRequest(Error("ORCID id is not configured.")))
+          Left(BadRequest(Error("ORCiD ID is not linked.")))
             .toEitherT[Future]
 
         orcidId = loggedInUser.orcidAuthorization.get.orcid

--- a/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
@@ -348,28 +348,6 @@ class TestUsersController extends BaseApiTest {
     }
   }
 
-//  test("orcid creation") {
-//    val orcidRequest = write(
-//      ORCIDRequest(
-//        ORCIDAuthorizationInfo(
-//          source = "orcid-redirect-response",
-//          code = testAuthorizationCode
-//        )
-//      )
-//    )
-//
-//    postJson(
-//      s"/orcid",
-//      orcidRequest,
-//      headers = authorizationHeader(loggedInJwt)
-//    ) {
-//      status should equal(200)
-//      val result = parsedBody.extract[OrcidDTO]
-//      result.name should be(orcidAuthorization.name)
-//      result.orcid should be(orcidAuthorization.orcid)
-//    }
-//  }
-
   test("orcid link succeeds with valid body") {
     val validRequest = write(
       ORCIDRequest(

--- a/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestUsersController.scala
@@ -348,8 +348,30 @@ class TestUsersController extends BaseApiTest {
     }
   }
 
-  test("orcid creation") {
-    val orcidRequest = write(
+//  test("orcid creation") {
+//    val orcidRequest = write(
+//      ORCIDRequest(
+//        ORCIDAuthorizationInfo(
+//          source = "orcid-redirect-response",
+//          code = testAuthorizationCode
+//        )
+//      )
+//    )
+//
+//    postJson(
+//      s"/orcid",
+//      orcidRequest,
+//      headers = authorizationHeader(loggedInJwt)
+//    ) {
+//      status should equal(200)
+//      val result = parsedBody.extract[OrcidDTO]
+//      result.name should be(orcidAuthorization.name)
+//      result.orcid should be(orcidAuthorization.orcid)
+//    }
+//  }
+
+  test("orcid link succeeds with valid body") {
+    val validRequest = write(
       ORCIDRequest(
         ORCIDAuthorizationInfo(
           source = "orcid-redirect-response",
@@ -360,7 +382,7 @@ class TestUsersController extends BaseApiTest {
 
     postJson(
       s"/orcid",
-      orcidRequest,
+      validRequest,
       headers = authorizationHeader(loggedInJwt)
     ) {
       status should equal(200)
@@ -370,7 +392,24 @@ class TestUsersController extends BaseApiTest {
     }
   }
 
-  test("orcid deletion") {
+  test("orcid link fails with invalid body") {
+    val invalidRequest = write(
+      ORCIDAuthorizationInfo(
+        source = "orcid-redirect-response",
+        code = testAuthorizationCode
+      )
+    )
+
+    postJson(
+      s"/orcid",
+      invalidRequest,
+      headers = authorizationHeader(loggedInJwt)
+    ) {
+      status should equal(400)
+    }
+  }
+
+  test("orcid unlink succeeds with linked Cognito identity") {
     val orcidRequest = write(
       ORCIDRequest(
         ORCIDAuthorizationInfo(
@@ -379,6 +418,7 @@ class TestUsersController extends BaseApiTest {
         )
       )
     )
+    // first we POST to link the ORCID iD, then we DELETE to unlink it
     postJson(
       s"/orcid",
       orcidRequest,
@@ -389,6 +429,36 @@ class TestUsersController extends BaseApiTest {
         body shouldBe empty
         status should equal(200)
       }
+    }
+  }
+
+  test("orcid unlink succeeds without linked Cognito identity") {
+    val orcidRequest = write(
+      ORCIDRequest(
+        ORCIDAuthorizationInfo(
+          source = "orcid-redirect-response",
+          code = testAuthorizationCode
+        )
+      )
+    )
+    // first we POST to link the ORCID iD, then we DELETE to unlink it
+    postJson(
+      s"/orcid",
+      orcidRequest,
+      headers = authorizationHeader(colleagueJwt)
+    ) {
+      status should equal(200)
+      delete(s"/orcid", headers = authorizationHeader(colleagueJwt)) {
+        body shouldBe empty
+        status should equal(200)
+      }
+    }
+  }
+
+  test("orcid unlink fails when ORCID iD is not linked") {
+    delete(s"/orcid", headers = authorizationHeader(externalJwt)) {
+      body shouldBe """{"message":"ORCiD ID is not linked."}"""
+      status should equal(400)
     }
   }
 

--- a/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
@@ -364,8 +364,12 @@ class Cognito(
         .toScala
         .map(response => response.userAttributes())
 
+      // TODO: if there is an "identities" entry, we will need to filter on `providerName`
+      // TODO: this will be imperative once we support multiple Identity Providers
+      // TODO: for now, we can determine by the presence of a non-empty value (it will be ORCID)
       result = attributes.asScala.toList
-        .map(_.name().equals("identities"))
+        .filter(_.name.equals("identities"))
+        .map(!_.value.equals("[]"))
         .foldLeft(false)(_ || _)
 
     } yield result

--- a/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoClient.scala
+++ b/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoClient.scala
@@ -61,6 +61,10 @@ class MockCognito() extends CognitoClient {
   val userPasswordSets: mutable.ArrayBuffer[String] =
     mutable.ArrayBuffer.empty
 
+  val usersWithLinkedOrcidId: mutable.ArrayBuffer[String] =
+    // loggedInUser(me) and externalUser(other)
+    mutable.ArrayBuffer() ++= List[String]("test@test.com", "test@external.com")
+
   def inviteUser(
     email: Email,
     suppressEmail: Boolean = false,
@@ -116,7 +120,8 @@ class MockCognito() extends CognitoClient {
     providerName: String
   )(implicit
     ec: ExecutionContext
-  ): Future[Boolean] = Future.successful(true)
+  ): Future[Boolean] =
+    Future.successful(usersWithLinkedOrcidId.contains(username))
 
   def unlinkExternalUser(
     providerName: String,
@@ -126,6 +131,7 @@ class MockCognito() extends CognitoClient {
     ec: ExecutionContext
   ): Future[Unit] = {
     unlinkedExternalUsers.append((providerName, attributeName, attributeValue))
+    usersWithLinkedOrcidId -= attributeValue
     Future.successful(())
   }
 


### PR DESCRIPTION
## Changes Proposed

- change the way `hasExternalUserLink()` checks the response from Cognito
  - note: this response changed, which is why unlinking was failing
  - there are TODO items here for later, when we implement additional Federated Identity Providers
- adjust the returned error message
- enhance **MockCognitoClient** to be more robust in `hasExternalUserLink()`
- add some tests around orcid id linking and unlinking

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
