### PR TITLE
Upgrade Pennsieve PostgreSQL seed database version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ lazy val flywayVersion = "4.2.0"
 lazy val json4sVersion = "3.5.5"
 
 lazy val jettyVersion = "9.1.3.v20140225"
-lazy val postgresVersion = "42.1.4"
+lazy val postgresVersion = "42.7.3"
 lazy val scalatraVersion = "2.7.1"
 
 lazy val scalatestVersion = "3.2.11"

--- a/core/src/test/scala/com/pennsieve/test/PostgresDockerContainer.scala
+++ b/core/src/test/scala/com/pennsieve/test/PostgresDockerContainer.scala
@@ -24,7 +24,7 @@ import java.time.Duration
 
 final class PostgresDockerContainerImpl
     extends PostgresContainerImpl(
-      dockerImage = "pennsieve/pennsievedb:V20230315145959"
+      dockerImage = "pennsieve/pennsievedb:V20240603122900"
     )
 
 trait PostgresDockerContainer extends StackedDockerContainer {
@@ -35,7 +35,7 @@ trait PostgresDockerContainer extends StackedDockerContainer {
 
 final class PostgresSeedDockerContainerImpl
     extends PostgresContainerImpl(
-      dockerImage = "pennsieve/pennsievedb:V20230315145959-seed"
+      dockerImage = "pennsieve/pennsievedb:V20240603122900-seed"
     )
 
 trait PostgresSeedDockerContainer extends StackedDockerContainer {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   postgres:
     hostname: postgres
-    image: pennsieve/postgres:9.6.5
+    image: pennsieve/postgres:16.3
     environment:
       POSTGRES_PASSWORD: password
       PGPASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   postgres:
     hostname: postgres
     image: pennsieve/postgres:16.3
+    platform: linux/amd64
     environment:
       POSTGRES_PASSWORD: password
       PGPASSWORD: password


### PR DESCRIPTION
## Changes Proposed
**ClickUp Ticket:** [8688zghwn](https://app.clickup.com/t/8688zghwn)

Upgrade the Pennsieve seed database to 16.3.

### Related PRs
-  https://github.com/Pennsieve/docker-base-images/pull/1
- https://github.com/Pennsieve/discover-pgdump-lambda/pull/1

 ## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
