### PR TITLE
Feature/track GitHub repos p3

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -350,6 +350,8 @@ class DataSetsController(
 
   implicit val publicationTypeParam = Param.enumParam(PublicationType)
 
+  implicit val datasetTypeParam = Param.enumParam(DatasetType)
+
   implicit val orderByColumnParam =
     Param.enumParam(DatasetManager.OrderByColumn)
 
@@ -729,7 +731,9 @@ class DataSetsController(
             .description(
               "If true, information about publication will be returned"
             )
-            .defaultValue(false)
+            .defaultValue(false),
+          queryParam[String]("type").optional
+            .description("Specify the type of datasets to be returned")
       )
     )
   ) {
@@ -821,6 +825,8 @@ class DataSetsController(
 
           canPublish <- optParamT[Boolean]("canPublish")
 
+          datasetType <- optParamT[DatasetType]("type")
+
           datasetsAndCount <- secureContainer.datasetManager
             .getDatasetPaginated(
               withRole = ownerOnly.getOrElse(withRole.getOrElse(Role.Viewer)),
@@ -834,7 +840,8 @@ class DataSetsController(
               canPublish = canPublish,
               restrictToRole = withRole.isDefined || ownerOnly.isDefined,
               collectionId = collectionId,
-              isGuest
+              isGuest = isGuest,
+              datasetType = datasetType
             )
             .coreErrorToActionResult()
 

--- a/api/src/main/scala/com/pennsieve/helpers/ModelSerializers.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/ModelSerializers.scala
@@ -75,7 +75,9 @@ object ModelSerializers {
     Json4s.serializer(ChangelogEventName),
     Json4s.serializer(EventGroupPeriod),
     Json4s.serializer(RelationshipType),
-    Json4s.serializer(IntegrationTarget)
+    Json4s.serializer(IntegrationTarget),
+    Json4s.serializer(DatasetReleaseStatus),
+    Json4s.serializer(DatasetReleasePublishingStatus)
   )
 }
 

--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -10517,7 +10517,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       status should equal(200)
       val dto = parsedBody.extract[DataSetDTO]
       dto.content.datasetType should equal(DatasetType.Research)
-      dto.content.release should equal(None)
+      dto.content.releases should equal(None)
     }
   }
 
@@ -10553,8 +10553,9 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       status should equal(200)
       val dto = parsedBody.extract[DataSetDTO]
       dto.content.datasetType should equal(DatasetType.Release)
-      dto.content.release shouldNot equal(None)
-      dto.content.release.get should equal(release)
+      dto.content.releases shouldNot equal(None)
+      dto.content.releases.get.length should equal(1)
+      dto.content.releases.get should equal(Seq(release))
     }
   }
 }

--- a/core-models/src/main/scala/com/pennsieve/dtos/WrappedDataset.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/WrappedDataset.scala
@@ -44,14 +44,14 @@ case class WrappedDataset(
   tags: List[String],
   dataUseAgreementId: Option[Int],
   intId: Int,
-  release: Option[DatasetRelease]
+  releases: Option[Seq[DatasetRelease]]
 )
 
 object WrappedDataset {
   def apply(
     dataset: Dataset,
     status: DatasetStatus,
-    release: Option[DatasetRelease] = None
+    releases: Option[Seq[DatasetRelease]] = None
   ): WrappedDataset = {
     WrappedDataset(
       id = dataset.nodeId,
@@ -68,7 +68,7 @@ object WrappedDataset {
       tags = dataset.tags,
       dataUseAgreementId = dataset.dataUseAgreementId,
       intId = dataset.id,
-      release = release
+      releases = releases
     )
   }
 

--- a/core-models/src/main/scala/com/pennsieve/models/DatasetRelease.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetRelease.scala
@@ -18,8 +18,43 @@ package com.pennsieve.models
 
 import io.circe.{ Decoder, Encoder }
 import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+import enumeratum._
+import enumeratum.EnumEntry._
+
+import scala.collection.immutable
 
 import java.time.ZonedDateTime
+
+sealed trait DatasetReleaseStatus extends EnumEntry with Snakecase
+
+object DatasetReleaseStatus
+    extends Enum[DatasetReleaseStatus]
+    with CirceEnum[DatasetReleaseStatus] {
+  val values: immutable.IndexedSeq[DatasetReleaseStatus] = findValues
+
+  case object Created extends DatasetReleaseStatus
+  case object Deleted extends DatasetReleaseStatus
+  case object Edited extends DatasetReleaseStatus
+  case object Prereleased extends DatasetReleaseStatus
+  case object Published extends DatasetReleaseStatus
+  case object Released extends DatasetReleaseStatus
+  case object Unpublished extends DatasetReleaseStatus
+}
+
+sealed trait DatasetReleasePublishingStatus extends EnumEntry with Snakecase
+
+object DatasetReleasePublishingStatus
+    extends Enum[DatasetReleasePublishingStatus]
+    with CirceEnum[DatasetReleasePublishingStatus] {
+  val values: immutable.IndexedSeq[DatasetReleasePublishingStatus] = findValues
+
+  case object Initial extends DatasetReleasePublishingStatus
+  case object Ready extends DatasetReleasePublishingStatus
+  case object NotReady extends DatasetReleasePublishingStatus
+  case object InProgress extends DatasetReleasePublishingStatus
+  case object Succeeded extends DatasetReleasePublishingStatus
+  case object Failed extends DatasetReleasePublishingStatus
+}
 
 final case class DatasetRelease(
   id: Int = 0,
@@ -32,7 +67,9 @@ final case class DatasetRelease(
   properties: List[ModelProperty] = List.empty,
   tags: List[String] = List.empty,
   createdAt: ZonedDateTime = ZonedDateTime.now(),
-  updatedAt: ZonedDateTime = ZonedDateTime.now()
+  updatedAt: ZonedDateTime = ZonedDateTime.now(),
+  releaseStatus: String = DatasetReleaseStatus.Created.toString,
+  publishingStatus: String = DatasetReleasePublishingStatus.Initial.toString
 )
 
 object DatasetRelease {

--- a/core-models/src/main/scala/com/pennsieve/models/DatasetRelease.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetRelease.scala
@@ -68,8 +68,9 @@ final case class DatasetRelease(
   tags: List[String] = List.empty,
   createdAt: ZonedDateTime = ZonedDateTime.now(),
   updatedAt: ZonedDateTime = ZonedDateTime.now(),
-  releaseStatus: String = DatasetReleaseStatus.Created.toString,
-  publishingStatus: String = DatasetReleasePublishingStatus.Initial.toString
+  releaseStatus: DatasetReleaseStatus = DatasetReleaseStatus.Created,
+  publishingStatus: DatasetReleasePublishingStatus =
+    DatasetReleasePublishingStatus.Initial
 )
 
 object DatasetRelease {

--- a/core/src/main/scala/com/pennsieve/db/DatasetReleaseTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DatasetReleaseTable.scala
@@ -42,6 +42,8 @@ final class DatasetReleaseTable(schema: String, tag: Tag)
   def tags = column[List[String]]("tags")
   def createdAt = column[ZonedDateTime]("created_at", O.AutoInc)
   def updatedAt = column[ZonedDateTime]("updated_at", O.AutoInc)
+  def releaseStatus = column[String]("release_status")
+  def publishingStatus = column[String]("publishing_status")
 
   def * =
     (
@@ -55,7 +57,9 @@ final class DatasetReleaseTable(schema: String, tag: Tag)
       properties,
       tags,
       createdAt,
-      updatedAt
+      updatedAt,
+      releaseStatus,
+      publishingStatus
     ).mapTo[DatasetRelease]
 }
 
@@ -65,9 +69,20 @@ class DatasetReleaseMapper(organization: Organization)
     datasetId: Int
   )(implicit
     ec: ExecutionContext
+  ): DBIO[Seq[DatasetRelease]] =
+    this
+      .filter(_.datasetId === datasetId)
+      .result
+
+  def getLatest(
+    datasetId: Int
+  )(implicit
+    ec: ExecutionContext
   ): DBIO[Option[DatasetRelease]] =
     this
       .filter(_.datasetId === datasetId)
+      .sortBy(_.createdAt.desc)
+      .take(1)
       .result
       .headOption
 

--- a/core/src/main/scala/com/pennsieve/db/DatasetReleaseTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DatasetReleaseTable.scala
@@ -19,6 +19,8 @@ package com.pennsieve.db
 import com.pennsieve.models.{
   Dataset,
   DatasetRelease,
+  DatasetReleasePublishingStatus,
+  DatasetReleaseStatus,
   ModelProperty,
   Organization
 }
@@ -42,8 +44,9 @@ final class DatasetReleaseTable(schema: String, tag: Tag)
   def tags = column[List[String]]("tags")
   def createdAt = column[ZonedDateTime]("created_at", O.AutoInc)
   def updatedAt = column[ZonedDateTime]("updated_at", O.AutoInc)
-  def releaseStatus = column[String]("release_status")
-  def publishingStatus = column[String]("publishing_status")
+  def releaseStatus = column[DatasetReleaseStatus]("release_status")
+  def publishingStatus =
+    column[DatasetReleasePublishingStatus]("publishing_status")
 
   def * =
     (

--- a/core/src/main/scala/com/pennsieve/db/DatasetReleaseTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/DatasetReleaseTable.scala
@@ -65,13 +65,15 @@ final class DatasetReleaseTable(schema: String, tag: Tag)
 
 class DatasetReleaseMapper(organization: Organization)
     extends TableQuery(new DatasetReleaseTable(organization.schemaId, _)) {
-  def get(
+
+  def getAll(
     datasetId: Int
   )(implicit
     ec: ExecutionContext
   ): DBIO[Seq[DatasetRelease]] =
     this
       .filter(_.datasetId === datasetId)
+      .sortBy(_.createdAt.desc)
       .result
 
   def getLatest(
@@ -83,6 +85,18 @@ class DatasetReleaseMapper(organization: Organization)
       .filter(_.datasetId === datasetId)
       .sortBy(_.createdAt.desc)
       .take(1)
+      .result
+      .headOption
+
+  def get(
+    datasetId: Int,
+    label: String
+  )(implicit
+    ec: ExecutionContext
+  ): DBIO[Option[DatasetRelease]] =
+    this
+      .filter(_.datasetId === datasetId)
+      .filter(_.label === label)
       .result
       .headOption
 

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -243,10 +243,10 @@ object Builders {
         Future[Option[List[PackageDTO]]](None).toEitherT
       }
 
-      datasetRelease <- if (dataset.`type`.equals(DatasetType.Release)) {
-        secureContainer.datasetManager.getRelease(dataset.id)
+      datasetReleases <- if (dataset.`type`.equals(DatasetType.Release)) {
+        secureContainer.datasetManager.getReleases(dataset.id)
       } else {
-        Future[Option[DatasetRelease]](None).toEitherT
+        Future[Option[Seq[DatasetRelease]]](None).toEitherT
       }
 
       collaboratorCounts <- secureContainer.datasetManager
@@ -288,7 +288,7 @@ object Builders {
 
     } yield
       DataSetDTO(
-        WrappedDataset(dataset, status, datasetRelease),
+        WrappedDataset(dataset, status, datasetReleases),
         secureContainer.organization.nodeId,
         children,
         owner.nodeId,

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -1777,13 +1777,27 @@ class DatasetManager(
         }
     } yield true
 
-  def getRelease(
+  def getReleases(
     datasetId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Option[Seq[DatasetRelease]]] =
+    for {
+      releases <- db.run(datasetReleaseMapper.getAll(datasetId)).toEitherT
+    } yield
+      (releases.length match {
+        case 0 => None
+        case _ => Some(releases)
+      })
+
+  def getRelease(
+    datasetId: Int,
+    label: String
   )(implicit
     ec: ExecutionContext
   ): EitherT[Future, CoreError, Option[DatasetRelease]] =
     for {
-      release <- db.run(datasetReleaseMapper.getLatest(datasetId)).toEitherT
+      release <- db.run(datasetReleaseMapper.get(datasetId, label)).toEitherT
     } yield (release)
 
   def addRelease(

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -1477,7 +1477,8 @@ class DatasetManager(
     canPublish: Option[Boolean] = None,
     restrictToRole: Boolean = false,
     collectionId: Option[Int] = None,
-    isGuest: Boolean = false
+    isGuest: Boolean = false,
+    datasetType: Option[DatasetType] = None
   )(implicit
     ec: ExecutionContext
   ): EitherT[Future, CoreError, (Seq[DatasetAndStatus], Long)] = {
@@ -1499,8 +1500,9 @@ class DatasetManager(
           val query = datasetsMapper.withoutDeleted
             .filter(_.id.inSet(datasetIds))
 
-            // (2) Only match datasets with the supplied status:
+            // (2) Only match datasets with the supplied status and dataset type:
             .filterOpt(status)(_.statusId === _.id)
+            .filterOpt(datasetType)(_.`type` === _)
 
             // (3) Add users:
             .join(datasetUser)

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -1783,7 +1783,7 @@ class DatasetManager(
     ec: ExecutionContext
   ): EitherT[Future, CoreError, Option[DatasetRelease]] =
     for {
-      release <- db.run(datasetReleaseMapper.get(datasetId)).toEitherT
+      release <- db.run(datasetReleaseMapper.getLatest(datasetId)).toEitherT
     } yield (release)
 
   def addRelease(

--- a/core/src/main/scala/com/pennsieve/traits/PostgresProfile.scala
+++ b/core/src/main/scala/com/pennsieve/traits/PostgresProfile.scala
@@ -206,6 +206,18 @@ trait PostgresProfile
     implicit val datasetTypeMapper = MappedColumnType
       .base[DatasetType, String](_.entryName, DatasetType.withName)
 
+    implicit val datasetReleaseStatusMapper =
+      MappedColumnType.base[DatasetReleaseStatus, String](
+        _.entryName,
+        DatasetReleaseStatus.withName
+      )
+
+    implicit val datasetReleasePublishingStatusMapper =
+      MappedColumnType.base[DatasetReleasePublishingStatus, String](
+        _.entryName,
+        DatasetReleasePublishingStatus.withName
+      )
+
     implicit val embargoAccessMapper = MappedColumnType
       .base[EmbargoAccess, String](_.entryName, EmbargoAccess.withName)
 

--- a/core/src/test/scala/com/pennsieve/managers/DatasetManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/DatasetManagerSpec.scala
@@ -1272,6 +1272,31 @@ class DatasetManagerSpec extends BaseManagerSpec {
 
   }
 
+  "dataset selection" should "permit filtering by `type`" in {
+    val user = createUser()
+    val dm = datasetManager(user = user)
+    // create a dataset, type = 'research'
+    val dataset1 = createDataset(user = user, `type` = DatasetType.Research)
+    // create a dataset, type = 'release'
+    val dataset2 = createDataset(user = user, `type` = DatasetType.Release)
+    val (datasets, count) = dm
+      .getDatasetPaginated(
+        withRole = Role.Owner,
+        limit = Some(5),
+        offset = Some(0),
+        orderBy = (OrderByColumn.Name, OrderByDirection.Asc),
+        status = None,
+        textSearch = None,
+        datasetType = Some(DatasetType.Release)
+      )
+      .await
+      .value
+
+    count shouldEqual 1
+    datasets.length shouldEqual 1
+    datasets.head.dataset shouldBe dataset2
+  }
+
   "a dataset release" should "be added to a dataset of type 'release'" in {
     val releaseLabel = "v0.0.1"
     val user = createUser()

--- a/core/src/test/scala/com/pennsieve/managers/DatasetManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/DatasetManagerSpec.scala
@@ -1273,6 +1273,7 @@ class DatasetManagerSpec extends BaseManagerSpec {
   }
 
   "a dataset release" should "be added to a dataset of type 'release'" in {
+    val releaseLabel = "v0.0.1"
     val user = createUser()
     val dataset = createDataset(user = user, `type` = DatasetType.Release)
     val dm = datasetManager(user = user)
@@ -1282,7 +1283,7 @@ class DatasetManagerSpec extends BaseManagerSpec {
           datasetId = dataset.id,
           origin = "GitHub",
           url = "https://github.com/Pennsieve/test-repo-x1",
-          label = Some("v0.0.1"),
+          label = Some(releaseLabel),
           marker = Some("423c1ba"),
           releaseDate = Some(ZonedDateTime.now())
         )
@@ -1290,7 +1291,7 @@ class DatasetManagerSpec extends BaseManagerSpec {
       .await
       .value
 
-    assert(dm.getRelease(dataset.id).await.value == Some(release))
+    assert(dm.getRelease(dataset.id, releaseLabel).await.value == Some(release))
   }
 
   it should "not be added to a dataset that is not type 'release'" in {
@@ -1324,14 +1325,15 @@ class DatasetManagerSpec extends BaseManagerSpec {
       .await
       .value
 
+    val releaseLabel = "v1.0.0"
     val update = release.copy(
-      label = Some("v1.0.0"),
+      label = Some(releaseLabel),
       marker = Some("9b44a7e"),
       releaseDate = Some(ZonedDateTime.now())
     )
 
     val _ = dm.updateRelease(update).await.value
-    val updated = dm.getRelease(dataset.id).await.value.get
+    val updated = dm.getRelease(dataset.id, releaseLabel).await.value.get
     assert(updated.label == update.label)
     assert(updated.marker == update.marker)
   }
@@ -1356,6 +1358,34 @@ class DatasetManagerSpec extends BaseManagerSpec {
     val user = createUser()
     val dataset = createDataset(user = user)
     val dm = datasetManager(user = user)
-    assert(dm.getRelease(dataset.id).await.value == None)
+    assert(dm.getReleases(dataset.id).await.value == None)
+  }
+
+  it should "be ordered by createdAt timestamp when there are multiple releases" in {
+    val user = createUser()
+    val dataset = createDataset(user = user, `type` = DatasetType.Release)
+    val dm = datasetManager(user = user)
+    val releaseDetails =
+      Seq(("v1.0.0", "abc123"), ("v2.0.0", "def234"), ("v3.0.0", "ghi345"))
+    releaseDetails.foreach(
+      details =>
+        dm.addRelease(
+            DatasetRelease(
+              datasetId = dataset.id,
+              origin = "GitHub",
+              url = "https://github.com/Pennsieve/test-repo-x1",
+              label = Some(details._1),
+              marker = Some(details._2),
+              releaseDate = Some(ZonedDateTime.now())
+            )
+          )
+          .await
+    )
+
+    val releases = dm.getReleases(dataset.id).await.value.get
+    assert(releases.length == 3)
+    assert(
+      releases.map(r => (r.label.get, r.marker.get)) == releaseDetails.reverse
+    )
   }
 }

--- a/migrations/src/main/resources/db/migrations/V20240823134000__external_repositories_auto_process_and_sync.sql
+++ b/migrations/src/main/resources/db/migrations/V20240823134000__external_repositories_auto_process_and_sync.sql
@@ -1,0 +1,2 @@
+ALTER TABLE external_repositories ADD COLUMN auto_process BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE external_repositories ADD COLUMN synchronize JSONB;

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20240823134600__dataset_release_add_status_tracking.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20240823134600__dataset_release_add_status_tracking.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dataset_release ADD COLUMN release_status TEXT NOT NULL;
+ALTER TABLE dataset_release ADD COLUMN publishing_status TEXT NOT NULL;


### PR DESCRIPTION
## Changes Proposed
Expand `external_repositories` table, adding columns to track whether we **automatically process** release events and publish, and track which attributes we attempt to **synchronize** with GitHub (e.g., README, banner, changelog, contributors, license).

Expand the `dataset_release` table to track **release status** (the GitHub release state) and **publishing status**.

Expanded `DatasetDTO` (`WrappedDataset`) to return a list of releases, ordered by creation time (newest to oldest).

Added the ability to filter datasets by type in the *Get Datasets - paginated* endpoint.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.

### Unit Tests
- added for testing filtering ability by dataset type

### Security Implications
None.

### Deployment Considerations
Expands *Get Datasets - paginated* endpoint with additional query parameter. Does not change or impact other options or capabilities in this function.
