### PR TITLE
Feature/export all packages

### DIFF
--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -1180,8 +1180,8 @@ class PackageManager(datasetManager: DatasetManager) {
                      name,
                      type,
                      state
-              from "367".packages
-              where dataset_id = 2190
+              from "#${organization.schemaId}".packages
+              where dataset_id = ${dataset.id}
                 and parent_id is null
               union
               select parents.depth+1 as depth,
@@ -1193,7 +1193,7 @@ class PackageManager(datasetManager: DatasetManager) {
                      children.name,
                      children.type,
                      children.state
-              from "367".packages children
+              from "#${organization.schemaId}".packages children
               INNER JOIN export_packages parents
               ON children.parent_id = parents.id
             )

--- a/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
@@ -1065,4 +1065,15 @@ class PackageManagerSpec extends BaseManagerSpec {
     result1.value.map(_._2) shouldBe Vector(Seq(file, otherFile))
   }
 
+  "package export" should "have empty path for top-level package" in {
+    val user = createUser()
+    val pm = packageManager(user = user)
+
+    val dataset = createDataset(user = user)
+    val p = createPackage(user = user, dataset = dataset)
+    val result = pm.exportAll(dataset).await.value
+    result.length shouldEqual (1)
+    result.head._2.length shouldEqual (0)
+  }
+
 }

--- a/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
@@ -1065,7 +1065,9 @@ class PackageManagerSpec extends BaseManagerSpec {
     result1.value.map(_._2) shouldBe Vector(Seq(file, otherFile))
   }
 
-  "package export" should "have empty path for top-level package" in {
+  behavior of "package export"
+
+  it should "have empty path for top-level package" in {
     val user = createUser()
     val pm = packageManager(user = user)
 
@@ -1076,7 +1078,7 @@ class PackageManagerSpec extends BaseManagerSpec {
     result.head._2.length shouldEqual 0
   }
 
-  "package export" should "provide the folder path for packages" in {
+  it should "provide the folder path for packages" in {
     val user = createUser()
     val pm = packageManager(user = user)
 
@@ -1151,7 +1153,7 @@ class PackageManagerSpec extends BaseManagerSpec {
       .map(_._2) shouldBe Vector(Seq(dataFolderName, derivedFolderName))
   }
 
-  "package export" should "return a zero-length response for a dataset with no packages" in {
+  it should "return a zero-length response for a dataset with no packages" in {
     val user = createUser()
     val pm = packageManager(user = user)
 

--- a/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
@@ -1072,8 +1072,8 @@ class PackageManagerSpec extends BaseManagerSpec {
     val dataset = createDataset(user = user)
     val p = createPackage(user = user, dataset = dataset)
     val result = pm.exportAll(dataset).await.value
-    result.length shouldEqual (1)
-    result.head._2.length shouldEqual (0)
+    result.length shouldEqual 1
+    result.head._2.length shouldEqual 0
   }
 
   "package export" should "provide the folder path for packages" in {
@@ -1149,6 +1149,15 @@ class PackageManagerSpec extends BaseManagerSpec {
     result
       .filter((_._1.name.equals(derivedFileName)))
       .map(_._2) shouldBe Vector(Seq(dataFolderName, derivedFolderName))
+  }
+
+  "package export" should "return a zero-length response for a dataset with no packages" in {
+    val user = createUser()
+    val pm = packageManager(user = user)
+
+    val dataset = createDataset(user = user)
+    val result = pm.exportAll(dataset).await.value
+    result.length shouldBe 0
   }
 
 }

--- a/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
@@ -1076,4 +1076,79 @@ class PackageManagerSpec extends BaseManagerSpec {
     result.head._2.length shouldEqual (0)
   }
 
+  "package export" should "provide the folder path for packages" in {
+    val user = createUser()
+    val pm = packageManager(user = user)
+
+    val dataset = createDataset(user = user)
+
+    // create the folder structure
+    val dataFolderName = "data"
+    val sourceFolderName = "source"
+    val derivedFolderName = "derived"
+
+    val dataFolderPackage =
+      createPackage(user = user, dataset = dataset, name = dataFolderName)
+    val sourceFolderPackage = createPackage(
+      user = user,
+      dataset = dataset,
+      name = sourceFolderName,
+      parent = Some(dataFolderPackage)
+    )
+    val derivedFolderPackage = createPackage(
+      user = user,
+      dataset = dataset,
+      name = derivedFolderName,
+      parent = Some(dataFolderPackage)
+    )
+
+    // attach files to the packages
+    val manifestFileName = "manifest.json"
+    val sourceFileName = "source.dat"
+    val derivedFileName = "derived.csv"
+
+    val manifestFilePackage = createPackage(
+      user = user,
+      dataset = dataset,
+      name = manifestFileName,
+      `type` = PackageType.Unsupported,
+      parent = Some(dataFolderPackage)
+    )
+    val manifestFile =
+      createFile(container = manifestFilePackage, name = manifestFileName)
+
+    val sourceFilePackage = createPackage(
+      user = user,
+      dataset = dataset,
+      name = sourceFileName,
+      `type` = PackageType.Unknown,
+      parent = Some(sourceFolderPackage)
+    )
+    val sourceFile =
+      createFile(container = sourceFolderPackage, name = sourceFileName)
+
+    val derivedFilePackage = createPackage(
+      user = user,
+      dataset = dataset,
+      name = derivedFileName,
+      `type` = PackageType.CSV,
+      parent = Some(derivedFolderPackage)
+    )
+    val derivedFile =
+      createFile(container = derivedFolderPackage, name = derivedFileName)
+
+    val result = pm.exportAll(dataset).await.value
+
+    result.length shouldEqual (6)
+    result
+      .filter((_._1.name.equals(manifestFileName)))
+      .map(_._2) shouldBe Vector(Seq(dataFolderName))
+    result.filter((_._1.name.equals(sourceFileName))).map(_._2) shouldBe Vector(
+      Seq(dataFolderName, sourceFolderName)
+    )
+    result
+      .filter((_._1.name.equals(derivedFileName)))
+      .map(_._2) shouldBe Vector(Seq(dataFolderName, derivedFolderName))
+  }
+
 }


### PR DESCRIPTION
## Changes Proposed

Adds `PackageManager.exportAll()` function which exports the Package hierarchy for a dataset using a PostgreSQL **RECURSIVE** query. The "folder path" to where the Package resides is included in the result as an ordered `Seq()` of strings. This is to directly support Discover Publish, and remove an inefficient mechanism.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
