### PR TITLE
Fix/include dataset releases in datasets dto

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/DatasetRelease.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetRelease.scala
@@ -32,6 +32,7 @@ object DatasetReleaseStatus
     with CirceEnum[DatasetReleaseStatus] {
   val values: immutable.IndexedSeq[DatasetReleaseStatus] = findValues
 
+  case object Never extends DatasetReleaseStatus
   case object Created extends DatasetReleaseStatus
   case object Deleted extends DatasetReleaseStatus
   case object Edited extends DatasetReleaseStatus
@@ -48,6 +49,7 @@ object DatasetReleasePublishingStatus
     with CirceEnum[DatasetReleasePublishingStatus] {
   val values: immutable.IndexedSeq[DatasetReleasePublishingStatus] = findValues
 
+  case object Never extends DatasetReleasePublishingStatus
   case object Initial extends DatasetReleasePublishingStatus
   case object Ready extends DatasetReleasePublishingStatus
   case object NotReady extends DatasetReleasePublishingStatus

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -185,9 +185,19 @@ object Builders {
                 )
                 .toEitherT[Future]
 
+              datasetReleases <- if (dataset.`type`.equals(DatasetType.Release)) {
+                secureContainer.datasetManager.getReleases(dataset.id)
+              } else {
+                Future[Option[Seq[DatasetRelease]]](None).toEitherT
+              }
+
             } yield
               DataSetDTO(
-                content = WrappedDataset(dataset, datasetAndStatus.status),
+                content = WrappedDataset(
+                  dataset,
+                  datasetAndStatus.status,
+                  datasetReleases
+                ),
                 organization = secureContainer.organization.nodeId,
                 children = None,
                 owner = owner.nodeId,


### PR DESCRIPTION
## Changes Proposed

A `DatasetDTO` can be created by two `dtos.Builders` functions:
- `datasetDTO()`: receives on dataset
- `datasetDTOs()`: receives a Seq of datasets

The `datasetDTOs()` function iterates over the Seq, but was not getting the `DatasetRelease`s for each dataset before making a `WrappedDataset` and enveloping that into a `DatasetDTO`. The `datasetDTO()` function was doing this, and the correction is to add the step to the `datasetDTOs()` function.

Arguably there is a refactoring here that the `datasetDTOs()` function should call the `datasetDTO()` as it traverses the Seq, and we have just one place which prepares a `DatasetDTO`. (perhaps this can be done at a later date)

Also adds `Never` enum value to each of `DatasetReleaseStatus` and `DatasetReleasePublishingStatus` for initial DatasetRelease creation.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
