### PR TITLE
Use DOI link for Published Dataset URL in ORCID Work record 

### DIFF
--- a/api/src/main/scala/com/pennsieve/helpers/OrcidClient.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/OrcidClient.scala
@@ -190,10 +190,12 @@ class OrcidClientImpl(
             )
           case None => List.empty[OrcidExternalId]
         }),
-      url = OrcidTitleValue(value = work.publishedDatasetId match {
-        case Some(publishedDatasetId: Int) =>
+      url = OrcidTitleValue(value = (work.doi, work.publishedDatasetId) match {
+        case (Some(doi), _) =>
+          s"https://doi.org/${doi}"
+        case (None, Some(publishedDatasetId: Int)) =>
           s"https://${orcidClientConfig.discoverAppHost}/datasets/${publishedDatasetId}"
-        case None =>
+        case (None, None) =>
           s"https://${orcidClientConfig.discoverAppHost}"
       }),
       putCode = work.orcidPutCode


### PR DESCRIPTION
## Changes Proposed

- prefer DOI link
- then Dataset link on Pennsieve Discover
- final fallback is Pennsieve Discover (top)

[ClickUp ticket](https://app.clickup.com/t/8687xxe31)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
