### PR TITLE
Feature/include ext repo settings in dataset dto

### DIFF
--- a/api/src/main/scala/com/pennsieve/helpers/ModelSerializers.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/ModelSerializers.scala
@@ -77,7 +77,9 @@ object ModelSerializers {
     Json4s.serializer(RelationshipType),
     Json4s.serializer(IntegrationTarget),
     Json4s.serializer(DatasetReleaseStatus),
-    Json4s.serializer(DatasetReleasePublishingStatus)
+    Json4s.serializer(DatasetReleasePublishingStatus),
+    Json4s.serializer(ExternalRepositoryType),
+    Json4s.serializer(ExternalRepositoryStatus)
   )
 }
 

--- a/core-models/src/main/scala/com/pennsieve/dtos/WrappedDataset.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/WrappedDataset.scala
@@ -53,7 +53,7 @@ object WrappedDataset {
   def apply(
     dataset: Dataset,
     status: DatasetStatus,
-    repository: Option[ExternalRepository],
+    repository: Option[ExternalRepository] = None,
     releases: Option[Seq[DatasetRelease]] = None
   ): WrappedDataset = {
     WrappedDataset(

--- a/core-models/src/main/scala/com/pennsieve/dtos/WrappedDataset.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/WrappedDataset.scala
@@ -24,6 +24,7 @@ import com.pennsieve.models.{
   DatasetStatus,
   DatasetType,
   DefaultDatasetStatus,
+  ExternalRepository,
   License
 }
 import io.circe.{ Decoder, Encoder }
@@ -44,6 +45,7 @@ case class WrappedDataset(
   tags: List[String],
   dataUseAgreementId: Option[Int],
   intId: Int,
+  repository: Option[ExternalRepository],
   releases: Option[Seq[DatasetRelease]]
 )
 
@@ -51,6 +53,7 @@ object WrappedDataset {
   def apply(
     dataset: Dataset,
     status: DatasetStatus,
+    repository: Option[ExternalRepository],
     releases: Option[Seq[DatasetRelease]] = None
   ): WrappedDataset = {
     WrappedDataset(
@@ -68,6 +71,7 @@ object WrappedDataset {
       tags = dataset.tags,
       dataUseAgreementId = dataset.dataUseAgreementId,
       intId = dataset.id,
+      repository = repository,
       releases = releases
     )
   }

--- a/core-models/src/main/scala/com/pennsieve/models/ExternalRepository.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/ExternalRepository.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto.{ deriveDecoder, deriveEncoder }
+
+import enumeratum._
+import enumeratum.EnumEntry._
+
+import java.time.ZonedDateTime
+import scala.collection.immutable
+
+case class SyncSetting(setting: String, value: Boolean)
+object SyncSetting {
+  implicit val encoder: Encoder[SyncSetting] = deriveEncoder[SyncSetting]
+  implicit val decoder: Decoder[SyncSetting] = deriveDecoder[SyncSetting]
+}
+
+sealed trait ExternalRepositoryType extends EnumEntry with Snakecase
+
+object ExternalRepositoryType
+    extends Enum[ExternalRepositoryType]
+    with CirceEnum[ExternalRepositoryType] {
+  val values: immutable.IndexedSeq[ExternalRepositoryType] = findValues
+
+  case object Unknown extends ExternalRepositoryType
+  case object Publishing extends ExternalRepositoryType
+  case object AppStore extends ExternalRepositoryType
+}
+
+sealed trait ExternalRepositoryStatus extends EnumEntry with Snakecase
+
+object ExternalRepositoryStatus
+    extends Enum[ExternalRepositoryStatus]
+    with CirceEnum[ExternalRepositoryStatus] {
+  val values: immutable.IndexedSeq[ExternalRepositoryStatus] = findValues
+
+  case object Unknown extends ExternalRepositoryStatus
+  case object Enabled extends ExternalRepositoryStatus
+  case object Disabled extends ExternalRepositoryStatus
+  case object Suspended extends ExternalRepositoryStatus
+}
+
+case class ExternalRepository(
+  id: Int = 0,
+  origin: String,
+  `type`: ExternalRepositoryType,
+  url: String,
+  organizationId: Int,
+  userId: Int,
+  datasetId: Option[Int] = None,
+  applicationId: Option[Int] = None,
+  status: ExternalRepositoryStatus,
+  autoProcess: Boolean = false,
+  synchronize: List[SyncSetting] = List.empty,
+  createdAt: ZonedDateTime = ZonedDateTime.now(),
+  updatedAt: ZonedDateTime = ZonedDateTime.now()
+)
+
+object ExternalRepository {
+  implicit val encoder: Encoder[ExternalRepository] =
+    deriveEncoder[ExternalRepository]
+  implicit val decoder: Decoder[ExternalRepository] =
+    deriveDecoder[ExternalRepository]
+
+  val tupled = (this.apply _).tupled
+}

--- a/core/src/main/scala/com/pennsieve/db/ExternalRepositoriesTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/ExternalRepositoriesTable.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.db
+
+import com.pennsieve.models.{
+  ExternalRepository,
+  ExternalRepositoryStatus,
+  ExternalRepositoryType,
+  SyncSetting
+}
+
+import com.pennsieve.traits.PostgresProfile.api._
+import slick.dbio.Effect
+
+import java.time.ZonedDateTime
+
+final class ExternalRepositoriesTable(tag: Tag)
+    extends Table[ExternalRepository](
+      tag,
+      Some("pennsieve"),
+      "external_repositories"
+    ) {
+
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def origin = column[String]("origin")
+  def `type` = column[ExternalRepositoryType]("type")
+  def url = column[String]("url")
+  def organizationId = column[Int]("organization_id")
+  def userId = column[Int]("user_id")
+  def datasetId = column[Option[Int]]("dataset_id")
+  def applicationId = column[Option[Int]]("application_id")
+  def status = column[ExternalRepositoryStatus]("status")
+  def autoProcess = column[Boolean]("auto_process")
+  def synchronize = column[List[SyncSetting]]("synchronize")
+  def createdAt = column[ZonedDateTime]("created_at", O.AutoInc)
+  def updatedAt = column[ZonedDateTime]("updated_at", O.AutoInc)
+
+  def * =
+    (
+      id,
+      origin,
+      `type`,
+      url,
+      organizationId,
+      userId,
+      datasetId,
+      applicationId,
+      status,
+      autoProcess,
+      synchronize,
+      createdAt,
+      updatedAt
+    ).mapTo[ExternalRepository]
+}
+
+class ExternalRepositoryMapper
+    extends TableQuery(new ExternalRepositoriesTable(_)) {
+  def getExternalRepository(
+    organizationId: Int,
+    datasetId: Int
+  ): DBIO[Option[ExternalRepository]] =
+    this
+      .filter(_.organizationId === organizationId)
+      .filter(_.datasetId === datasetId)
+      .result
+      .headOption
+}

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -160,6 +160,9 @@ class DatasetManager(
   val datasetReleaseMapper: DatasetReleaseMapper =
     new DatasetReleaseMapper(organization)
 
+  val externalRepositoryMapper: ExternalRepositoryMapper =
+    new ExternalRepositoryMapper()
+
   def isLocked(
     dataset: Dataset
   )(implicit
@@ -1827,4 +1830,19 @@ class DatasetManager(
       )(PredicateError(s"dataset type must be ${DatasetType.Release.toString}"))
       release <- db.run(datasetReleaseMapper.update(release)).toEitherT
     } yield release
+
+  def getExternalRepository(
+    organizationId: Int,
+    datasetId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Option[ExternalRepository]] =
+    for {
+      repository <- db
+        .run(
+          externalRepositoryMapper
+            .getExternalRepository(organizationId, datasetId)
+        )
+        .toEitherT
+    } yield repository
 }

--- a/core/src/main/scala/com/pennsieve/traits/PostgresProfile.scala
+++ b/core/src/main/scala/com/pennsieve/traits/PostgresProfile.scala
@@ -166,6 +166,24 @@ trait PostgresProfile
         s => IntegrationTarget.withName(s)
       )
 
+    implicit val externalRepositoryTypeMapper =
+      MappedColumnType.base[ExternalRepositoryType, String](
+        _.entryName,
+        ExternalRepositoryType.withName
+      )
+
+    implicit val externalRepositoryStatusMapper =
+      MappedColumnType.base[ExternalRepositoryStatus, String](
+        _.entryName,
+        ExternalRepositoryStatus.withName
+      )
+
+    implicit val syncSettingsMapper =
+      MappedColumnType.base[List[SyncSetting], Json](
+        settings => settings.asJson,
+        json => json.as[List[SyncSetting]].toOption.get
+      )
+
     implicit val annotationPathElementMapper =
       MappedColumnType.base[List[PathElement], Json](
         elements => elements.asJson,


### PR DESCRIPTION
## Changes Proposed

This PR adds the external repository details to the `DatasetDTO` for release-type datasets.

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
