### PR TITLE
define Dataset Metadata V5.0

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/DatasetMetadata.scala
@@ -124,6 +124,29 @@ case class DatasetMetadataV4_0(
   pennsieveSchemaVersion: String = "4.0"
 ) extends DatasetMetadata
 
+case class ReleaseMetadataV5_0(
+  origin: String, // GitHub
+  url: String, // https://github.com/org/repo
+  label: String, // tag
+  marker: String // commit hash
+)
+object ReleaseMetadataV5_0 {
+  implicit val encoder: Encoder[ReleaseMetadataV5_0] =
+    deriveEncoder[ReleaseMetadataV5_0]
+  implicit val decoder: Decoder[ReleaseMetadataV5_0] =
+    deriveDecoder[ReleaseMetadataV5_0]
+}
+
+case class ReferenceMetadataV5_0(
+  ids: Seq[String] // list of DOIs
+)
+object ReferenceMetadataV5_0 {
+  implicit val encoder: Encoder[ReferenceMetadataV5_0] =
+    deriveEncoder[ReferenceMetadataV5_0]
+  implicit val decoder: Decoder[ReferenceMetadataV5_0] =
+    deriveDecoder[ReferenceMetadataV5_0]
+}
+
 case class DatasetMetadataV5_0(
   pennsieveDatasetId: Int,
   version: Int,
@@ -139,13 +162,22 @@ case class DatasetMetadataV5_0(
   `@id`: String, // DOI
   publisher: String = "The University of Pennsylvania",
   `@context`: String = "http://schema.org/",
-  `@type`: String = "Dataset",
+  `@type`: String = "Dataset", // or "Release" , "Collection"
   schemaVersion: String = "http://schema.org/version/3.7/",
   collections: Option[List[PublishedCollection]] = None,
   relatedPublications: Option[List[PublishedExternalPublication]] = None,
   files: List[FileManifest] = List.empty,
-  pennsieveSchemaVersion: String = "4.0"
+  release: Option[ReleaseMetadataV5_0],
+  references: Option[ReferenceMetadataV5_0],
+  pennsieveSchemaVersion: String = "5.0"
 ) extends DatasetMetadata
+
+object DatasetMetadataV5_0 {
+  implicit val encoder: Encoder[DatasetMetadataV5_0] =
+    deriveEncoder[DatasetMetadataV5_0]
+  implicit val decoder: Decoder[DatasetMetadataV5_0] =
+    deriveDecoder[DatasetMetadataV5_0]
+}
 
 object DatasetMetadataV4_0 {
   implicit val encoder: Encoder[DatasetMetadataV4_0] =
@@ -204,6 +236,7 @@ object DatasetMetadata {
               stringSchema match {
                 case "3.0" => c.as[DatasetMetadataV3_0]
                 case "4.0" => c.as[DatasetMetadataV4_0]
+                case "5.0" => c.as[DatasetMetadataV5_0]
                 case _ =>
                   Left(
                     DecodingFailure(s"Could not recognize schema", c.history)

--- a/core-models/src/main/scala/com/pennsieve/models/License.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/License.scala
@@ -35,7 +35,8 @@ object License extends Enum[License] with CirceEnum[License] {
   case object `Creative Commons Zero 1.0 Universal` extends License
   case object `Creative Commons Attribution` extends License
   case object `Creative Commons Attribution - ShareAlike` extends License
-  case object `Creative Commons Attribution - NonCommercial-ShareAlike` extends License
+  case object `Creative Commons Attribution - NonCommercial-ShareAlike`
+      extends License
   case object `Eclipse Public License 2.0` extends License
   case object `GNU Affero General Public License v3.0` extends License
   case object `GNU General Public License v2.0` extends License
@@ -48,7 +49,8 @@ object License extends Enum[License] with CirceEnum[License] {
   case object `Mozilla Public License 2.0` extends License
   case object `Open Data Commons Open Database` extends License
   case object `Open Data Commons Attribution` extends License
-  case object `Open Data Commons Public Domain Dedication and License` extends License
+  case object `Open Data Commons Public Domain Dedication and License`
+      extends License
   case object `The Unlicense` extends License
 
   val licenseUri: Map[License, String] = Map(


### PR DESCRIPTION
## Changes Proposed

Adds support for:
- **Code Repos**: the record of a release is stored in the `release` attribute of the metadata
- **Collections**: the list of *referenced* datasets are stored in the `references` attribute of the metadata (these will be DOI links)

```scala
case class DatasetMetadataV5_0(
  pennsieveDatasetId: Int,
  version: Int,
  revision: Option[Int],
  name: String,
  description: String,
  creator: PublishedContributor,
  contributors: List[PublishedContributor],
  sourceOrganization: String,
  keywords: List[String],
  datePublished: LocalDate,
  license: Option[License],
  `@id`: String, // DOI
  publisher: String = "The University of Pennsylvania",
  `@context`: String = "http://schema.org/",
  `@type`: String = "Dataset", // or "Release" , "Collection"
  schemaVersion: String = "http://schema.org/version/3.7/",
  collections: Option[List[PublishedCollection]] = None,
  relatedPublications: Option[List[PublishedExternalPublication]] = None,
  files: List[FileManifest] = List.empty,
  release: Option[ReleaseMetadataV5_0],
  references: Option[ReferenceMetadataV5_0],
  pennsieveSchemaVersion: String = "5.0"
) extends DatasetMetadata
```

The `release` object contains the properties of a release:
```scala
case class ReleaseMetadataV5_0(
  origin: String, // GitHub
  url: String, // https://github.com/org/repo
  label: String, // tag
  marker: String // commit hash
)
```

## Deployment considerations:
Readers and Writers of Dataset Metadata will need to be able to handle the V5.0 schema. Principals definitely subject to this are:
- Discover Publish
- Discover Service


## Checklist

- [ ] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
