### PR TITLE
Feature - send email to Publishing Team when dataset submitted for review

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetPublishingHelper.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetPublishingHelper.scala
@@ -405,12 +405,11 @@ case object DataSetPublishingHelper extends LazyLogging {
     contributors: Seq[ContributorDTO],
     dataset: Dataset,
     organization: Organization,
-    owner: User,
-    publishers: Seq[User]
+    owner: User
   )(implicit
     ec: ExecutionContext
   ): EitherT[Future, ActionResult, List[SesMessageResult]] = {
-    val set1 = uniqueEmails(owner, contributors.map(_.email))
+    uniqueEmails(owner, contributors.map(_.email))
       .traverse { contributorEmail =>
         {
           val message =
@@ -442,8 +441,18 @@ case object DataSetPublishingHelper extends LazyLogging {
 
         }
       }
+  }
 
-    val _ = publishers
+  def emailPublishersPublicationRequest(
+    insecureContainer: InsecureAPIContainer,
+    owner: User,
+    dataset: Dataset,
+    organization: Organization,
+    publishers: Seq[User]
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, ActionResult, Seq[SesMessageResult]] = {
+    publishers
       .traverse { publisher =>
         {
           val message =
@@ -477,8 +486,6 @@ case object DataSetPublishingHelper extends LazyLogging {
             .toEitherT[Future]
         }
       }
-
-    set1
   }
 
   def emailManagersEmbargoAccessRequested(

--- a/api/src/main/scala/com/pennsieve/api/DataSetPublishingHelper.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetPublishingHelper.scala
@@ -405,11 +405,12 @@ case object DataSetPublishingHelper extends LazyLogging {
     contributors: Seq[ContributorDTO],
     dataset: Dataset,
     organization: Organization,
-    owner: User
+    owner: User,
+    publishers: Seq[User]
   )(implicit
     ec: ExecutionContext
   ): EitherT[Future, ActionResult, List[SesMessageResult]] = {
-    uniqueEmails(owner, contributors.map(_.email))
+    uniqueEmails(owner, contributors.map(_.email) ++ publishers.map(_.email))
       .traverse { contributorEmail =>
         {
           val message =

--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -3086,17 +3086,30 @@ class DataSetsController(
             )
             .coreErrorToActionResult()
 
-          publishers <- secureContainer.organizationManager
-            .getPublishingTeamMembers(secureContainer.organization)
-            .coreErrorToActionResult()
-
           _ <- if (validated.publicationType == PublicationType.Publication) {
             DataSetPublishingHelper.emailContributorsPublicationRequest(
               insecureContainer,
               contributors,
               validated.dataset,
               secureContainer.organization,
+              secureContainer.user
+            )
+          } else {
+            EitherT
+              .rightT[Future, CoreError](List[SesMessageResult]())
+              .coreErrorToActionResult()
+          }
+
+          publishers <- secureContainer.organizationManager
+            .getPublishingTeamMembers(secureContainer.organization)
+            .coreErrorToActionResult()
+
+          _ <- if (validated.publicationType == PublicationType.Publication) {
+            DataSetPublishingHelper.emailPublishersPublicationRequest(
+              insecureContainer,
               secureContainer.user,
+              validated.dataset,
+              secureContainer.organization,
               publishers
             )
           } else {

--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -3086,13 +3086,18 @@ class DataSetsController(
             )
             .coreErrorToActionResult()
 
+          publishers <- secureContainer.organizationManager
+            .getPublishingTeamMembers(secureContainer.organization)
+            .coreErrorToActionResult()
+
           _ <- if (validated.publicationType == PublicationType.Publication) {
             DataSetPublishingHelper.emailContributorsPublicationRequest(
               insecureContainer,
               contributors,
               validated.dataset,
               secureContainer.organization,
-              secureContainer.user
+              secureContainer.user,
+              publishers
             )
           } else {
             EitherT

--- a/api/src/main/scala/com/pennsieve/api/DiscussionsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DiscussionsController.scala
@@ -76,12 +76,14 @@ class DiscussionsController(
   )
     summary "get a discussion[deprecated]"
     parameter pathParam[String]("id").description("the id of the package")
-    deprecated(true))
-
+    deprecated (true))
 
   get("/package/:id", operation(getDiscussionOperation)) {
 
-    response.setHeader("Warning", "299 - 'getDiscussionOperation' is deprecated and will be removed on Nov 1 2025")
+    response.setHeader(
+      "Warning",
+      "299 - 'getDiscussionOperation' is deprecated and will be removed on Nov 1 2025"
+    )
 
     new AsyncResult {
       val result = for {
@@ -160,12 +162,15 @@ class DiscussionsController(
   val createCommentOperation = (apiOperation[CommentResponse]("createComment")
     summary "creates a comment and/or a discussion[deprecated]"
     parameter bodyParam[CreateCommentRequest]("createAnnotationRequest")
-    deprecated(true))
+    deprecated (true))
 
   post("/", operation(createCommentOperation)) {
     val req = parsedBody.extract[CreateCommentRequest]
 
-    response.setHeader("Warning", "299 - 'createComment' is deprecated and will be removed on Nov 1 2025")
+    response.setHeader(
+      "Warning",
+      "299 - 'createComment' is deprecated and will be removed on Nov 1 2025"
+    )
 
     new AsyncResult {
       val result = for {
@@ -261,11 +266,14 @@ class DiscussionsController(
       .description("the id of the comment")
     parameter pathParam[String]("discussionId")
       .description("the id of the discussion")
-    deprecated(true))
+    deprecated (true))
 
   delete("/:discussionId/comment/:commentId", operation(deleteCommentOperation)) {
 
-    response.setHeader("Warning", "299 - 'deleteComment' is deprecated and will be removed on Nov 1 2025")
+    response.setHeader(
+      "Warning",
+      "299 - 'deleteComment' is deprecated and will be removed on Nov 1 2025"
+    )
 
     new AsyncResult {
       val result: EitherT[Future, ActionResult, Int] = for {
@@ -321,11 +329,14 @@ class DiscussionsController(
     summary "delete a discussion[deprecated]"
     parameter pathParam[String]("discussionId")
       .description("the id of the discussion")
-    deprecated(true))
+    deprecated (true))
 
   delete("/:discussionId", operation(deleteDiscussionOperation)) {
 
-    response.setHeader("Warning", "299 - 'deleteDiscussion' is deprecated and will be removed on Nov 1 2025")
+    response.setHeader(
+      "Warning",
+      "299 - 'deleteDiscussion' is deprecated and will be removed on Nov 1 2025"
+    )
 
     new AsyncResult {
       val result: EitherT[Future, ActionResult, Int] = for {
@@ -377,12 +388,15 @@ class DiscussionsController(
       .description("the id of the discussion")
     parameter pathParam[String]("commentId")
       .description("the id of the comment")
-    deprecated(true))
+    deprecated (true))
 
   put("/:discussionId/comment/:commentId", operation(updateCommentOperation)) {
     val req = parsedBody.extract[UpdateCommentRequest]
 
-    response.setHeader("Warning", "299 - 'updateComment' is deprecated and will be removed on Nov 1 2025")
+    response.setHeader(
+      "Warning",
+      "299 - 'updateComment' is deprecated and will be removed on Nov 1 2025"
+    )
 
     new AsyncResult {
       val result = for {

--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -4968,19 +4968,21 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       .asInstanceOf[LoggingEmailer]
       .sentEmails
 
+    // Note: the 'colleague' user is added to the Publishers team in initializePublicationTest()
+    // and the 'publisher' user is added to the Publishers team in ApiSuite.beforeEach()
     sentMessages.map(_.subject).toList shouldBe List.concat(
       alreadySentMessagesSubjectList,
       List(
         "Dataset Submitted for Review", //submitted
-        "Dataset Submitted for Review", //cc: Publishers Team (colleague)
-        "Dataset Submitted for Review", //cc: Publishers Team (publisher)
+        "Dataset Submitted to Publishers for Review", //cc: Publishers Team (colleague)
+        "Dataset Submitted to Publishers for Review", //cc: Publishers Team (publisher)
         "Dataset Revision needed", //rejected
         "Dataset Submitted for Review", //submitted
-        "Dataset Submitted for Review", //cc: Publishers Team (colleague)
-        "Dataset Submitted for Review", //cc: Publishers Team (publisher)
-        "Dataset Submitted for Review", //submitted again after cancel (cancel doe snot send email for now)
-        "Dataset Submitted for Review", //cc: Publishers Team (colleague)
-        "Dataset Submitted for Review", //cc: Publishers Team (publisher)
+        "Dataset Submitted to Publishers for Review", //cc: Publishers Team (colleague)
+        "Dataset Submitted to Publishers for Review", //cc: Publishers Team (publisher)
+        "Dataset Submitted for Review", //submitted again after cancel (cancel does not send email for now)
+        "Dataset Submitted to Publishers for Review", //cc: Publishers Team (colleague)
+        "Dataset Submitted to Publishers for Review", //cc: Publishers Team (publisher)
         "Dataset Accepted", //accepted
         "Dataset Published to Pennsieve Discover" //published
       )

--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -4972,9 +4972,15 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
       alreadySentMessagesSubjectList,
       List(
         "Dataset Submitted for Review", //submitted
+        "Dataset Submitted for Review", //cc: Publishers Team (colleague)
+        "Dataset Submitted for Review", //cc: Publishers Team (publisher)
         "Dataset Revision needed", //rejected
         "Dataset Submitted for Review", //submitted
+        "Dataset Submitted for Review", //cc: Publishers Team (colleague)
+        "Dataset Submitted for Review", //cc: Publishers Team (publisher)
         "Dataset Submitted for Review", //submitted again after cancel (cancel doe snot send email for now)
+        "Dataset Submitted for Review", //cc: Publishers Team (colleague)
+        "Dataset Submitted for Review", //cc: Publishers Team (publisher)
         "Dataset Accepted", //accepted
         "Dataset Published to Pennsieve Discover" //published
       )

--- a/api/src/test/scala/com/pennsieve/api/TestDiscussionsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDiscussionsController.scala
@@ -99,9 +99,7 @@ class TestDiscussionsController extends BaseApiTest {
         "this is my home folder"
       )
       // Check that warning header has notice about deprecation
-      response.getHeader("Warning") should include(
-        "deprecated"
-      )
+      response.getHeader("Warning") should include("deprecated")
     }
   }
 
@@ -145,9 +143,7 @@ class TestDiscussionsController extends BaseApiTest {
         s"${annotation.id}"
       )
       // Check that warning header has notice about deprecation
-      response.getHeader("Warning") should include(
-        "deprecated"
-      )
+      response.getHeader("Warning") should include("deprecated")
     }
   }
 
@@ -173,9 +169,7 @@ class TestDiscussionsController extends BaseApiTest {
       assert(fetch.isLeft)
 
       // Check that warning header has notice about deprecation
-      response.getHeader("Warning") should include(
-        "deprecated"
-      )
+      response.getHeader("Warning") should include("deprecated")
     }
   }
 
@@ -189,9 +183,7 @@ class TestDiscussionsController extends BaseApiTest {
       assert(body.contains("Fine, thanks"))
       assert(body.contains(loggedInUser.nodeId))
       // Check that warning header has notice about deprecation
-      response.getHeader("Warning") should include(
-        "deprecated"
-      )
+      response.getHeader("Warning") should include("deprecated")
     }
   }
 
@@ -215,9 +207,7 @@ class TestDiscussionsController extends BaseApiTest {
       assert(upd.message == newmsg)
 
       // Check that warning header has notice about deprecation
-      response.getHeader("Warning") should include(
-        "deprecated"
-      )
+      response.getHeader("Warning") should include("deprecated")
 
     }
   }
@@ -234,9 +224,7 @@ class TestDiscussionsController extends BaseApiTest {
         secureContainer.discussionManager.getComment(comment.id).await
       assert(fetched.isLeft)
       // Check that warning header has notice about deprecation
-      response.getHeader("Warning") should include(
-        "deprecated"
-      )
+      response.getHeader("Warning") should include("deprecated")
     }
   }
 

--- a/core/src/main/scala/com/pennsieve/aws/email/Emailer.scala
+++ b/core/src/main/scala/com/pennsieve/aws/email/Emailer.scala
@@ -104,4 +104,8 @@ class LoggingEmailer extends Emailer with LazyLogging {
     subject: String
   ): Either[Throwable, SesMessageResult] =
     sendEmail(EmailToSend(to, from, message, subject))
+
+  def sendEmailTo(recipient: String): Boolean = {
+    sentEmails.filter(_.to.address.equalsIgnoreCase(recipient)).length > 0
+  }
 }

--- a/core/src/main/scala/com/pennsieve/core/utilities/MessageTemplates.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/MessageTemplates.scala
@@ -307,4 +307,26 @@ class MessageTemplates(
       customMessage = customMessage,
       setupAccountLink = setupAccountLink
     )
+
+  def datasetSubmittedForReview(
+    organizationName: String,
+    organizationNodeId: String,
+    datasetName: String,
+    datasetNodeId: String,
+    ownerName: String,
+    ownerEmailAddress: String,
+    emailAddress: String,
+    date: String
+  ): String =
+    GeneratedMessageTemplates.datasetSubmittedForReview(
+      host = host,
+      organizationName = organizationName,
+      organizationNodeId = organizationNodeId,
+      datasetName = datasetName,
+      datasetNodeId = datasetNodeId,
+      ownerName = ownerName,
+      ownerEmailAddress = ownerEmailAddress,
+      emailAddress = emailAddress,
+      date = date
+    )
 }

--- a/core/src/main/scala/com/pennsieve/managers/OrganizationManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/OrganizationManager.scala
@@ -475,6 +475,18 @@ class SecureOrganizationManager(val db: Database, val actor: User)
     } yield members.map(_.id) contains actor.id
   }
 
+  def getPublishingTeamMembers(
+    organization: Organization
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Seq[User]] =
+    for {
+      publisherTeam <- getPublisherTeam(organization)
+      members <- db
+        .run(TeamsMapper.getUsers(publisherTeam._1.id).result)
+        .toEitherT
+    } yield members
+
   def hasPermission(
     organization: Organization,
     permission: DBPermission

--- a/message-templates/html/dataset-submitted-for-review.html
+++ b/message-templates/html/dataset-submitted-for-review.html
@@ -1,0 +1,370 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>
+  </title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+  <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Roboto:300,400,500,700);
+    @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+  </style>
+  <!--<![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:320px) {
+      .mj-column-per-50 {
+        width: 50% !important;
+        max-width: 50%;
+      }
+
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+
+      .mj-column-px-96 {
+        width: 96px !important;
+        max-width: 96px;
+      }
+    }
+  </style>
+  <style media="screen and (min-width:320px)">
+    .moz-text-html .mj-column-per-50 {
+      width: 50% !important;
+      max-width: 50%;
+    }
+
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+    .moz-text-html .mj-column-px-96 {
+      width: 96px !important;
+      max-width: 96px;
+    }
+  </style>
+  <style type="text/css">
+  </style>
+</head>
+
+<body style="word-spacing:normal;background-color:#ffffff;">
+  <div class="body" style="overflow: hidden; background-color: #ffffff;">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#011f5b;background-color:#011f5b;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#011f5b;background-color:#011f5b;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 0px 0px 20px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:290px;" ><![endif]-->
+              <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <picture>
+                      <source height="67" width="320" srcset="https://app.pennsieve.net/assets/Upenn_FullLogo_Reverse_RGB-24d7f51c.png" media="(max-width: 500px)" style="display: block" alt="Pennsieve Logo">
+                      <img height="76" width="220" style="padding: 50px 0 20px 0" src="https://app.pennsieve.net/assets/Upenn_FullLogo_Reverse_RGB-24d7f51c.png" alt="Pennsieve Logo">
+                    </picture>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:290px;" ><![endif]-->
+              <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="background-color:#011f5b;vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0;padding-top:55px;word-break:break-word;">
+                        <div style="font-family:EB Garamond, serif;font-size:24px;line-height:1.5em;text-align:left;color:#ffffff;">Pennsieve Platform <i>for</i></div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                        <div style="font-family:EB Garamond, serif;font-size:24px;line-height:1.5em;text-align:left;color:#ffffff;">Data Management</div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0 43px 0 37px;padding-bottom:20px;padding-left:0;padding-right:0;padding-top:0;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="background-color:#011f5b;vertical-align:top;padding:18px 20px 35px 20px;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                                <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:1.5em;text-align:left;color:#ffffff;">
+                                  <h1 style="font-size: 1.875em; font-weight: 700; line-height: 1.2; margin: 1rem 0;">Dataset Publication Requested</h1>
+                                  <h2 style="font-size: 1.25em; margin: 0;">A dataset publication has been submitted for review.</h2>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0 43px 0 37px;padding-left:20px;padding-right:20px;text-align:left;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:560px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:16px 0;word-break:break-word;">
+                        <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:24px;text-align:left;color:#000000;">
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">A request to review a dataset publication has been submitted to the Publishing Team in the <b>${organizationName}</b> workspace. </p>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0 43px 0 37px;padding-left:20px;padding-right:20px;text-align:left;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:96px;" ><![endif]-->
+              <div class="mj-column-px-96 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:16px 0;word-break:break-word;">
+                        <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:1.5em;text-align:left;color:#000000;">
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">Dataset name:</p>
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">Dataset Id:</p>
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">Submitted by:</p>
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">Submitted on:</p>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td><td class="" style="vertical-align:top;width:280px;" ><![endif]-->
+              <div class="mj-column-per-50 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:16px 0;word-break:break-word;">
+                        <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:1.5em;text-align:left;color:#000000;">
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">${datasetName}</p>
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">${datasetNodeId}</p>
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">${ownerName} (${ownerEmailAddress})</p>
+                          <p style="font-size: .875em; margin: 0; line-height: 1.5rem;">${date}</p>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0 43px 0 37px;padding-left:20px;padding-right:20px;text-align:left;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:560px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="vertical-align:top;padding:16px 0;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="font-size:0px;padding:0;word-break:break-word;">
+                                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td height="40px" style="vertical-align:top;height:40px;"><![endif]-->
+                                <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:1.5em;text-align:left;color:#000000;height:40px;">
+                                  <!--[if mso]><v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://${host}/${organizationNodeId}/datasets/${datasetNodeId}" style="height:40px;v-text-anchor:middle;width:200px;" arcsize="8%" stroke="f" fillcolor="#5039F7"><w:anchorlock/><center><![endif]-->
+                                  <a href="https://${host}/${organizationNodeId}/datasets/${datasetNodeId}" style="background-color:#011f5b;border-radius:3px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:14px;font-weight:500;line-height:40px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;">View dataset</a>
+                                  <!--[if mso]></center></v:roundrect><![endif]-->
+                                </div>
+                                <!--[if mso | IE]></td></tr></table><![endif]-->
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0 43px 0 37px;padding-left:0;padding-right:0;padding-top:48px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="left" style="background:#011f5b;font-size:0px;padding:0;word-break:break-word;">
+                        <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:16px;line-height:1;table-layout:auto;width:100%;border:none;">
+                          <tr style="height: 72px">
+                            <td class="footer-blackfynn-logo-wrap" align="center" width="44" height="72" style="padding: 0 14px 0 14px; background-color: #011f5b;">
+                              <img class="footer-blackfynn-logo" align="center" src="https://app.pennsieve.net/static/emails/img/Pennsieve-Icon-White.png" alt="Pennsieve logo" height="32" width="32">
+                            </td>
+                            <td background-color="#5039F7" style="padding: 0 0 0 20px" vertical-align="center">
+                              <p class="social-wrap" style="font-size: .875em; line-height: 1.5rem; color: #ffffff; background-color: #011f5b; margin: 0;"> Follow us on <a href="https://twitter.com/pennsieve1" style="color: #ffffff; background-color: #011f5b; margin: 0;"><img src="https://app.pennsieve.net/static/emails/img/Twitter_Logo_Desktop_2x.png" height="16" width="16" alt="Twitter logo"></a>&nbsp;<a href="https://twitter.com/pennsieve1" style="color: #ffffff; background-color: #011f5b; margin: 0;">Twitter</a>
+                              </p>
+                            </td>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0 43px 0 37px;padding-left:20px;padding-right:20px;text-align:left;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:560px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                  <tbody>
+                    <tr>
+                      <td style="vertical-align:top;padding:27px 0 35px;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="left" class="copyright-wrap" style="font-size:0px;padding:0 0 8px;word-break:break-word;">
+                                <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:12px;line-height:18px;text-align:left;color:#000000;">
+                                  <p style="margin: 0; font-size: .75rem; line-height: 1.125rem;">This email was sent to ${emailAddress}.</p>
+                                </div>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" class="copyright-wrap" style="font-size:0px;padding:0;word-break:break-word;">
+                                <div style="font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;font-size:12px;line-height:18px;text-align:left;color:#000000;">
+                                  <p style="margin: 0; font-size: .75rem; line-height: 1.125rem;">Copyright &copy; 2024 University of Pennsylvania.<br>Penn Institute for Biomedical Informatics.<br> All rights reserved.</p>
+                                </div>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/message-templates/mjml/dataset-submitted-for-review.mjml
+++ b/message-templates/mjml/dataset-submitted-for-review.mjml
@@ -1,0 +1,104 @@
+<mjml>
+  <mj-head>
+    <mj-attributes>
+      <mj-text padding="0" />
+      <mj-button background-color="#5039F7" padding="12px 16px" color="#ffffff" font-size="14px" />
+      <mj-body background-color="#ffffff" />
+      <mj-all font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif" font-size="16px" line-height="1.5em" />
+      <mj-class name="kicker" font-size="16px" line-height="24px" />
+      <mj-class name="full-section" padding-left="0" padding-right="0" />
+      <mj-class name="copy-section" padding-left="20px" padding-right="20px" text-align="left" />
+    </mj-attributes>
+    <mj-style inline="inline">
+      h1 {
+        font-size: 1.875em;
+        font-weight: 700;
+        line-height: 1.2;
+        margin: 1rem 0;
+      }
+      h2 {
+        font-size: 1.25em;
+        margin: 0;
+      }
+      h3 {
+        font-size: .875em;
+        font-weight: bold;
+        margin: 0;
+      }
+      p {
+        font-size: .875em;
+        margin: 0;
+        line-height: 1.5rem;
+      }
+      .divider {
+        background: #2760ff;
+        height: 4px;
+        width: 33px;
+      }
+      .body {
+        overflow: hidden;
+      }
+    </mj-style>
+  </mj-head>
+  <mj-body css-class="body">
+    <mj-include path="./header.mjml" />
+
+    <mj-section mj-class="full-section" padding-top="0" padding-bottom="20px">
+      <mj-column background-color="#011f5b" padding="18px 20px 35px 20px">
+        <mj-text color="#ffffff" padding="0">
+          <h1>Dataset Publication Requested</h1>
+          <h2>A dataset publication has been submitted for review.</h2>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+   <mj-section mj-class="copy-section">
+      <mj-column>
+        <mj-text padding="16px 0" mj-class="kicker">
+          <p>A request to review a dataset publication has been submitted to the Publishing Team in the <b>${organizationName}</b> workspace. </p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+ <mj-section mj-class="copy-section">
+      <mj-column width="96px">
+        <mj-text padding="16px 0">
+          <p>Dataset name:</p>
+          <p>Dataset Id:</p>
+          <p>Submitted by:</p>
+          <p>Submitted on:</p>
+        </mj-text>
+      </mj-column>
+   <mj-column>
+     <mj-text padding="16px 0">
+          <p>${datasetName}</p>
+          <p>${datasetNodeId}</p>
+          <p>${ownerName} (${ownerEmailAddress})</p>
+          <p>${date}</p>
+     </mj-text>
+   </mj-column>
+    </mj-section>
+
+    <mj-section mj-class="copy-section">
+      <mj-column padding="16px 0">
+        <mj-text height="40px">
+          <!--[if mso]>
+            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://${host}/${organizationNodeId}/datasets/${datasetNodeId}" style="height:40px;v-text-anchor:middle;width:200px;" arcsize="8%" stroke="f" fillcolor="#5039F7">
+              <w:anchorlock/>
+              <center>
+            <![endif]-->
+                <a href="https://${host}/${organizationNodeId}/datasets/${datasetNodeId}"
+          style="background-color:#011f5b;border-radius:3px;color:#ffffff;display:inline-block;font-family:sans-serif;font-size:14px;font-weight:500;line-height:40px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;">View dataset</a>
+            <!--[if mso]>
+              </center>
+            </v:roundrect>
+          <![endif]-->
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+
+    <mj-include path="./footer-discover.mjml" />
+
+  </mj-body>
+</mjml>


### PR DESCRIPTION
## Changes Proposed

When a dataset publication is submitted for review, send an email to all members of the Publishers team in the workspace.

Added a new email template that is less verbose than the one sent to the dataset owner and contributors. The aim of the email template is to provide more specific data points relevant to a Publishing Team member: the dataset name, dataset node id, the dataset owner's name and email, and a link to the dataset. The name of the workspace where the publication request is also included.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
