### PR TITLE
Fix account sign up

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/TestAccountController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestAccountController.scala
@@ -182,27 +182,6 @@ class TestAccountController extends BaseApiTest {
     }
   }
 
-  test(
-    "sign up with an already existent email address should result in a 409 error"
-  ) {
-    val newUserRequest = CreateUserWithRecaptchaRequest(
-      firstName = "test",
-      middleInitial = None,
-      lastName = "tester",
-      degree = None,
-      title = Some(""),
-      email = "guest@test.com",
-      recaptchaToken = "foooo"
-    )
-
-    mockCognito.exception = UsernameExistsException.builder().build()
-
-    postJson("/sign-up", write(newUserRequest)) {
-      status should be(409)
-      body should include("An account with the given email already exists")
-    }
-  }
-
   ignore("update an external user invite") {
     // create a User
     val cognitoId = UUID.fromString(pennsieveUserId)

--- a/api/src/test/scala/com/pennsieve/api/TestAccountController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestAccountController.scala
@@ -23,7 +23,6 @@ import org.json4s.jackson.Serialization.write
 import org.scalatest.EitherValues._
 import pdi.jwt.{ JwtAlgorithm, JwtCirce }
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.cognitoidentityprovider.model.UsernameExistsException
 
 import java.time.{ Duration, Instant }
 import java.util.UUID

--- a/api/src/test/scala/com/pennsieve/api/TestAccountControllerMockIdentityProvider.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestAccountControllerMockIdentityProvider.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.api
+import com.blackfynn.clients.AntiSpamChallengeClient
+import com.pennsieve.aws.cognito.{
+  Cognito,
+  CognitoConfig,
+  CognitoPoolConfig,
+  MockCognitoIdentityProviderAsyncClient
+}
+import org.json4s.jackson.Serialization.write
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.cognitoidentityprovider.model.{
+  AdminCreateUserResponse,
+  AttributeType,
+  UserType,
+  UsernameExistsException
+}
+
+import java.util.UUID
+
+class TestAccountControllerMockIdentityProvider extends BaseApiTest {
+
+  private val cognitoConfig: CognitoConfig = CognitoConfig(
+    Region.US_EAST_1,
+    CognitoPoolConfig(Region.US_EAST_1, "user-pool-id", "client-id"),
+    CognitoPoolConfig(Region.US_EAST_1, "token-pool-id", "client-id"),
+    CognitoPoolConfig(Region.US_EAST_1, "identity-pool-id", "")
+  )
+
+  val recaptchaClient: AntiSpamChallengeClient =
+    new MockRecaptchaClient()
+
+  val mockIdentityProvider = new MockCognitoIdentityProviderAsyncClient()
+  val cognitoClient = new Cognito(mockIdentityProvider, cognitoConfig)
+
+  override def afterStart(): Unit = {
+    super.afterStart()
+
+    addServlet(
+      new AccountController(
+        insecureContainer,
+        cognitoConfig,
+        cognitoClient,
+        recaptchaClient,
+        system.dispatcher
+      ),
+      "/*"
+    )
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    mockIdentityProvider.reset()
+  }
+
+  test("create new account without an organization") {
+
+    val newUserRequest = CreateUserWithRecaptchaRequest(
+      firstName = "test",
+      middleInitial = None,
+      lastName = "tester",
+      degree = None,
+      title = Some(""),
+      email = "test@gmail.com",
+      recaptchaToken = "foooo"
+    )
+
+    val userCognitoId = UUID.randomUUID().toString
+    val user = UserType
+      .builder()
+      .attributes(
+        AttributeType
+          .builder()
+          .name("sub")
+          .value(userCognitoId)
+          .build()
+      )
+      .build()
+
+    mockIdentityProvider.adminCreateUserResponse =
+      Left(AdminCreateUserResponse.builder().user(user).build())
+
+    postJson("/sign-up", write(newUserRequest)) {
+      status should be(200)
+      assert(body.contains(welcomeOrganization.nodeId))
+    }
+  }
+
+  test(
+    "sign up with an already existent email address should result in a 409 error"
+  ) {
+    val newUserRequest = CreateUserWithRecaptchaRequest(
+      firstName = "test",
+      middleInitial = None,
+      lastName = "tester",
+      degree = None,
+      title = Some(""),
+      email = "guest@test.com",
+      recaptchaToken = "foooo"
+    )
+
+    mockIdentityProvider.adminCreateUserResponse =
+      Right(UsernameExistsException.builder().build())
+
+    postJson("/sign-up", write(newUserRequest)) {
+      println(parsedBody)
+      status should be(409)
+      body should include("An account with the given email already exists")
+    }
+  }
+}

--- a/api/src/test/scala/com/pennsieve/api/TestAccountControllerMockIdentityProvider.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestAccountControllerMockIdentityProvider.scala
@@ -33,6 +33,7 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.{
 
 import java.util.UUID
 
+// A test class for AccountController that uses a real CognitoClient implementation with a mock CognitoIdentityProviderAsyncClient
 class TestAccountControllerMockIdentityProvider extends BaseApiTest {
 
   private val cognitoConfig: CognitoConfig = CognitoConfig(

--- a/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
@@ -31,7 +31,6 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.{
   AdminDisableProviderForUserRequest,
   AdminDisableUserRequest,
   AdminGetUserRequest,
-  AdminInitiateAuthRequest,
   AdminSetUserPasswordRequest,
   AdminUpdateUserAttributesRequest,
   AttributeType,

--- a/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
+++ b/core/src/main/scala/com/pennsieve/aws/cognito/Cognito.scala
@@ -40,7 +40,8 @@ import software.amazon.awssdk.services.cognitoidentityprovider.model.{
   InitiateAuthRequest,
   MessageActionType,
   ProviderUserIdentifierType,
-  UserType
+  UserType,
+  UsernameExistsException
 }
 
 import java.util.UUID
@@ -48,6 +49,11 @@ import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.compat.java8.OptionConverters._
+
+// Helper to unwrap exception so we can match on cause
+object CausedBy {
+  def unapply(e: Throwable): Option[Throwable] = Option(e.getCause)
+}
 
 trait CognitoClient {
 
@@ -489,6 +495,11 @@ class Cognito(
       cognitoResponse <- client
         .adminCreateUser(request)
         .toScala
+        .recoverWith {
+          // The exception we want to match on is wrapped in a CompletionException
+          case CausedBy(ex: UsernameExistsException) =>
+            Future.failed(com.pennsieve.domain.UsernameExistsError(ex))
+        }
 
       cognitoId <- parseCognitoId(cognitoResponse.user()) match {
         case Some(cognitoId) => Future.successful(cognitoId)

--- a/core/src/main/scala/com/pennsieve/core/utilities/FutureEitherHelpers.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/FutureEitherHelpers.scala
@@ -62,7 +62,6 @@ object FutureEitherHelpers {
       ): EitherT[Future, CoreError, A] =
         f.toEitherT[CoreError] {
           case e: CoreError => e
-          case e: UsernameExistsException => UsernameExistsError(e)
           case e: Exception => ExceptionError(e)
         }
     }

--- a/core/src/main/scala/com/pennsieve/core/utilities/FutureEitherHelpers.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/FutureEitherHelpers.scala
@@ -18,8 +18,7 @@ package com.pennsieve.core.utilities
 
 import cats.data._
 import cats.implicits._
-import com.pennsieve.domain.{ CoreError, ExceptionError, UsernameExistsError }
-import software.amazon.awssdk.services.cognitoidentityprovider.model.UsernameExistsException
+import com.pennsieve.domain.{ CoreError, ExceptionError }
 
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoIdentityProviderAsyncClient.scala
+++ b/core/src/test/scala/com/pennsieve/aws/cognito/MockCognitoIdentityProviderAsyncClient.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.aws.cognito
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderAsyncClient
+import software.amazon.awssdk.services.cognitoidentityprovider.model.{
+  AdminCreateUserRequest,
+  AdminCreateUserResponse
+}
+
+import java.util.concurrent.CompletableFuture
+
+class UnsetMockResponseException(message: String) extends Exception(message) {}
+
+// A mock CognitoIdentityProviderAsyncClient. The trait has default implementations that throw UnsupportedOperationExceptions, so we only
+// need to implement methods actually used in tests.
+class MockCognitoIdentityProviderAsyncClient
+    extends CognitoIdentityProviderAsyncClient {
+
+  var adminCreateUserResponse: Either[AdminCreateUserResponse, Throwable] =
+    Right(new UnsetMockResponseException("adminCreateUser"))
+
+  override def close(): Unit = {}
+
+  override def serviceName(): String =
+    CognitoIdentityProviderAsyncClient.SERVICE_NAME
+
+  override def adminCreateUser(
+    adminCreateUserRequest: AdminCreateUserRequest
+  ): CompletableFuture[AdminCreateUserResponse] = {
+    CompletableFuture.supplyAsync(() => {
+      adminCreateUserResponse match {
+        case Left(value) => value
+        case Right(throwable) => throw throwable
+      }
+    })
+  }
+
+  def reset(): Unit = {
+    adminCreateUserResponse = Right(
+      new UnsetMockResponseException("adminCreateUser")
+    )
+  }
+
+}


### PR DESCRIPTION
## Changes Proposed
Builds on #301 to fix issue https://app.clickup.com/t/8688wej9y to make sure we return a 409 response instead of 500 when handling a `GET /account/sign-up` request for an already existing Cognito user.

The expected AWS exception in this case is being wrapped in a CompletionException, so we unwrap it in `CognitoClient` and rethrow as Pennsieve exception configured to result in a 409 response.

Adds a new test class for this which mocks the AWS Cognito identity provider client instead of our own `CognitoClient`.

## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
