### PR TITLE
Deprecate dataset and packages endpoints

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -572,8 +572,14 @@ class DataSetsController(
         parameters (
           pathParam[String]("id").description("data set id")
         )
+      deprecate
     )
   ) {
+    response.setHeader(
+      "Warning",
+      "299 - GET /datasets/:id/packageTypeCounts is deprecated and will be removed by December 31, 2025"
+    )
+
     new AsyncResult {
 
       val result: EitherT[Future, ActionResult, Map[String, Long]] = for {
@@ -613,8 +619,14 @@ class DataSetsController(
             )
             .defaultValue(false)
       )
+      deprecate
     )
   ) {
+    response.setHeader(
+      "Warning",
+      "299 - GET /datasets is deprecated and will be removed by December 31, 2025"
+    )
+
     new AsyncResult {
       val result: EitherT[Future, ActionResult, List[DataSetDTO]] =
         for {
@@ -2534,9 +2546,17 @@ class DataSetsController(
   )
     summary "get the user's effective role on the dataset"
     parameters
-      pathParam[String]("id").description("data set id"))
+      pathParam[String]("id").description("data set id")
+    deprecate
+    )
+
 
   get("/:id/role", operation(getDatasetRole)) {
+    response.setHeader(
+      "Warning",
+      "299 - GET /datasets/:id/role is deprecated and will be removed by December 31, 2025"
+    )
+
     new AsyncResult {
       val results: EitherT[Future, ActionResult, DatasetRoleResponse] =
         for {

--- a/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/DataSetsController.scala
@@ -571,8 +571,7 @@ class DataSetsController(
         summary "gets a data package type counts"
         parameters (
           pathParam[String]("id").description("data set id")
-        )
-      deprecate
+        ) deprecate
     )
   ) {
     response.setHeader(
@@ -618,8 +617,7 @@ class DataSetsController(
               "If true, information about publication will be returned"
             )
             .defaultValue(false)
-      )
-      deprecate
+      ) deprecate
     )
   ) {
     response.setHeader(
@@ -2541,15 +2539,11 @@ class DataSetsController(
     }
   }
 
-  val getDatasetRole: OperationBuilder = (apiOperation[DatasetRoleResponse](
-    "getDatasetRole"
-  )
-    summary "get the user's effective role on the dataset"
-    parameters
-      pathParam[String]("id").description("data set id")
-    deprecate
-    )
-
+  val getDatasetRole: OperationBuilder =
+    (apiOperation[DatasetRoleResponse]("getDatasetRole")
+      summary "get the user's effective role on the dataset"
+      parameters
+        pathParam[String]("id").description("data set id") deprecate)
 
   get("/:id/role", operation(getDatasetRole)) {
     response.setHeader(

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -1740,9 +1740,7 @@ class PackagesController(
     parameter pathParam[Int]("id")
       .description("the integer id of the package to update")
     parameter bodyParam[SetStorageRequest]("body")
-      .description("request body containing the new size of the package")
-    deprecate
-    )
+      .description("request body containing the new size of the package") deprecate)
 
   // this endpoint is deprecated and will go away in a future release v2.7.3
   put("/:id/storage", operation(putStorageOperation)) {

--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -1740,10 +1740,17 @@ class PackagesController(
     parameter pathParam[Int]("id")
       .description("the integer id of the package to update")
     parameter bodyParam[SetStorageRequest]("body")
-      .description("request body containing the new size of the package"))
+      .description("request body containing the new size of the package")
+    deprecate
+    )
 
   // this endpoint is deprecated and will go away in a future release v2.7.3
   put("/:id/storage", operation(putStorageOperation)) {
+    response.setHeader(
+      "Warning",
+      "299 - PUT /packages/:id/storage is deprecated and will be removed by December 31, 2025"
+    )
+
     new AsyncResult {
       val result: EitherT[Future, ActionResult, SetStorageResponse] = for {
         pkgId <- paramT[Int]("id")

--- a/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestDataSetsController.scala
@@ -5394,7 +5394,7 @@ class TestDataSetsController extends BaseApiTest with DataSetTestMixin {
     // The embargo release date should be propagated through the workflow
     get(
       s"/${dataset.nodeId}",
-      headers = jwtServiceAuthorizationHeader(loggedInOrganization) ++ traceIdHeader()
+      headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
     ) {
 
       status shouldBe 200

--- a/core-models/src/main/scala/com/pennsieve/dtos/DataSetDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/DataSetDTO.scala
@@ -37,7 +37,9 @@ case class DataSetDTO(
   properties: List[ModelPropertiesDTO] = List.empty,
   canPublish: Boolean,
   locked: Boolean,
-  bannerPresignedUrl: Option[URL] = None
+  bannerPresignedUrl: Option[URL] = None,
+  role: Option[Role],
+  packageTypeCounts: Option[Map[String, Int]] = None
 )
 
 object DataSetDTO {

--- a/core-models/src/main/scala/com/pennsieve/dtos/DataSetDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/DataSetDTO.scala
@@ -39,7 +39,7 @@ case class DataSetDTO(
   locked: Boolean,
   bannerPresignedUrl: Option[URL] = None,
   role: Option[Role] = None,
-  packageTypeCounts: Option[Map[String, Int]] = None
+  packageTypeCounts: Option[Map[String, Long]] = None
 )
 
 object DataSetDTO {

--- a/core-models/src/main/scala/com/pennsieve/dtos/DataSetDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/DataSetDTO.scala
@@ -38,7 +38,7 @@ case class DataSetDTO(
   canPublish: Boolean,
   locked: Boolean,
   bannerPresignedUrl: Option[URL] = None,
-  role: Option[Role],
+  role: Option[Role] = None,
   packageTypeCounts: Option[Map[String, Int]] = None
 )
 

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -234,8 +234,8 @@ object Builders {
                 canPublish = datasetAndStatus.canPublish,
                 locked = datasetAndStatus.locked,
                 bannerPresignedUrl = datasetBanners.get(dataset.id),
-                packageTypeCounts = counts,
-                role = role
+                packageTypeCounts = Some(counts),
+                role = Some(role)
               )
         }
     } yield dtos

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -188,6 +188,15 @@ object Builders {
 
               organizationId = secureContainer.organization.id
 
+              user = secureContainer.user
+
+              role <- secureContainer.datasetManager
+                .maxRole(dataset, user)
+
+              counts <- secureContainer.packageManager
+                .packageTypes(dataset)
+                .map(_.map { case (k, v) => (k.toString, v.toLong) })
+
               repository <- if (dataset.`type`.equals(DatasetType.Release)) {
                 secureContainer.datasetManager
                   .getExternalRepository(organizationId, dataset.id)
@@ -224,7 +233,9 @@ object Builders {
                 ),
                 canPublish = datasetAndStatus.canPublish,
                 locked = datasetAndStatus.locked,
-                bannerPresignedUrl = datasetBanners.get(dataset.id)
+                bannerPresignedUrl = datasetBanners.get(dataset.id),
+                packageTypeCounts = counts,
+                role = role
               )
         }
     } yield dtos
@@ -284,6 +295,15 @@ object Builders {
 
       owner <- secureContainer.datasetManager.getOwner(dataset)
 
+      user = secureContainer.user
+
+      role <- secureContainer.datasetManager
+        .maxRole(dataset, user)
+
+      counts <- secureContainer.packageManager
+        .packageTypes(dataset)
+        .map(_.map { case (k, v) => (k.toString, v.toLong) })
+
       publishedStatuses <- if (includePublishedDataset) {
         getPublishedDatasetsFromDiscover(
           secureContainer.organization,
@@ -331,7 +351,9 @@ object Builders {
         ),
         canPublish = canPublish,
         locked = locked,
-        bannerPresignedUrl = bannerPresignedUrl
+        bannerPresignedUrl = bannerPresignedUrl,
+        packageTypeCounts = Some(counts),
+        role = Some(role)
       )
   }
 


### PR DESCRIPTION
## Changes Proposed

Return a 299 warning header for the endpoints being deprecated. EOL date is December 31, 2025.

Add the requesting user's *Role* on the dataset and *Package Type Counts* for the dataset to the `DatasetDTO`, per requests from SODA and K Core teams. These are singular data items returned by the specific endpoints that are being deprecated.

[ClickUp ticket](https://app.clickup.com/t/8689yg0th)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
