### PR TITLE
WIP / Ideation: Switching out region for client on the fly

### DIFF
--- a/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
+++ b/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
@@ -41,7 +41,7 @@ final class S3DockerContainerImpl
       ),
       waitStrategy = Some(new HttpWaitStrategy().forPath("/minio/health/live")),
       command = Seq("server", "/tmp")
-    )
+    ) {
 
   def mappedPort(): Int = super.mappedPort(S3DockerContainer.port)
   val accessKey: String = S3DockerContainer.accessKey
@@ -97,6 +97,7 @@ final class S3DockerContainerImpl
       .withClientConfiguration(clientConfig)
       .build()
   }
+}
 
 trait S3DockerContainer extends StackedDockerContainer {
   val s3Container = DockerContainers.s3Container

--- a/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
+++ b/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
@@ -96,6 +96,19 @@ final class S3DockerContainerImpl
       .withClientConfiguration(clientConfig)
       .build()
   }
+  def s3ClientAFS: AmazonS3 = {
+    val creds = new BasicAWSCredentials(accessKey, secretKey)
+    val credsProvider = new AWSStaticCredentialsProvider(creds)
+    val endpoint = new EndpointConfiguration(endpointUrl, "af-south-1")
+    val clientConfig =
+      new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
+    AmazonS3ClientBuilder
+      .standard()
+      .withCredentials(credsProvider)
+      .withEndpointConfiguration(endpoint)
+      .withPathStyleAccessEnabled(true)
+      .withClientConfiguration(clientConfig)
+      .build()
 }
 
 trait S3DockerContainer extends StackedDockerContainer {

--- a/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
+++ b/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
@@ -82,12 +82,13 @@ final class S3DockerContainerImpl
         ConfigValueFactory.fromAnyRef("us-east-1")
       )
 
-  def s3Client: AmazonS3 = {
+
+  def createS3Client(region: String): AmazonS3 = {
     val creds = new BasicAWSCredentials(accessKey, secretKey)
     val credsProvider = new AWSStaticCredentialsProvider(creds)
-    val endpoint = new EndpointConfiguration(endpointUrl, "us-east-1")
-    val clientConfig =
-      new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
+    val endpoint = new EndpointConfiguration(endpointUrl, region)
+    val clientConfig = new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
+
     AmazonS3ClientBuilder
       .standard()
       .withCredentials(credsProvider)
@@ -96,20 +97,6 @@ final class S3DockerContainerImpl
       .withClientConfiguration(clientConfig)
       .build()
   }
-  def s3ClientAFS: AmazonS3 = {
-    val creds = new BasicAWSCredentials(accessKey, secretKey)
-    val credsProvider = new AWSStaticCredentialsProvider(creds)
-    val endpoint = new EndpointConfiguration(endpointUrl, "af-south-1")
-    val clientConfig =
-      new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
-    AmazonS3ClientBuilder
-      .standard()
-      .withCredentials(credsProvider)
-      .withEndpointConfiguration(endpoint)
-      .withPathStyleAccessEnabled(true)
-      .withClientConfiguration(clientConfig)
-      .build()
-}
 
 trait S3DockerContainer extends StackedDockerContainer {
   val s3Container = DockerContainers.s3Container

--- a/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
+++ b/core/src/test/scala/com/pennsieve/test/S3DockerContainer.scala
@@ -41,7 +41,7 @@ final class S3DockerContainerImpl
       ),
       waitStrategy = Some(new HttpWaitStrategy().forPath("/minio/health/live")),
       command = Seq("server", "/tmp")
-    ) {
+    )
 
   def mappedPort(): Int = super.mappedPort(S3DockerContainer.port)
   val accessKey: String = S3DockerContainer.accessKey


### PR DESCRIPTION
Just thinking this through so far. I'm sure there is more to it.

1. Is this the right approach? The client gets created on each  call to `getPresignedUrl` so it should only affect a single request at a time
2. Are there more places we need to add support for various regions? Probably yes for other actions, this is just the action that I noticed.