### PR TITLE
Deprecate a Packages "sources" endpoint

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -1369,9 +1369,14 @@ class PackagesController(
       queryParam[Int]("offset")
         .description("offset used for pagination of results")
         .defaultValue(FILES_OFFSET_DEFAULT)
-  ))
+  ) deprecate)
 
   get("/:id/sources", operation(getPackageSources)) {
+
+    response.setHeader(
+      "Warning",
+      "299 - GET /packages/:id/sources is deprecated and will be removed by December 31, 2025"
+    )
 
     new AsyncResult {
       val result: EitherT[Future, ActionResult, Seq[FileDTO]] = for {

--- a/api/src/main/scala/com/pennsieve/helpers/ObjectStore.scala
+++ b/api/src/main/scala/com/pennsieve/helpers/ObjectStore.scala
@@ -19,13 +19,13 @@ package com.pennsieve.helpers
 import com.pennsieve.api.Error
 import com.pennsieve.helpers.either.EitherErrorHandler.implicits._
 import com.pennsieve.web.Settings
-import com.pennsieve.aws.s3.{S3, S3ClientFactory}
+import com.pennsieve.aws.s3.{ S3, S3ClientFactory }
 import com.amazonaws.services.s3.model._
 import cats.syntax.either._
 import com.amazonaws.services.s3.AmazonS3
 
 import java.net.URL
-import org.scalatra.{ActionResult, InternalServerError, NotFound}
+import org.scalatra.{ ActionResult, InternalServerError, NotFound }
 
 import scala.util.Try
 import scala.concurrent.duration._
@@ -56,11 +56,11 @@ trait ObjectStore {
 class S3ObjectStore() extends ObjectStore {
 
   def getMD5(bucket: String, key: String): Either[ActionResult, String] = {
-      S3ClientFactory
-        .getClientForBucket(bucket)
-        .getObjectMetadata(bucket, key)
-        .map(_.getContentMD5)
-        .leftMap(t => InternalServerError(t.getMessage))
+    S3ClientFactory
+      .getClientForBucket(bucket)
+      .getObjectMetadata(bucket, key)
+      .map(_.getContentMD5)
+      .leftMap(t => InternalServerError(t.getMessage))
   }
   def getPresignedUrl(
     bucket: String,
@@ -69,15 +69,16 @@ class S3ObjectStore() extends ObjectStore {
     fileName: String
   ): Either[ActionResult, URL] = {
     // Create region appropriate client
-      S3ClientFactory
-        .getClientForBucket(bucket).generatePresignedUrl(
-          new GeneratePresignedUrlRequest(bucket, key)
-            .withExpiration(duration)
-            .withResponseHeaders(
-              new ResponseHeaderOverrides()
-                .withContentDisposition(s"""attachment; filename="$fileName"""")
-            )
-        )
+    S3ClientFactory
+      .getClientForBucket(bucket)
+      .generatePresignedUrl(
+        new GeneratePresignedUrlRequest(bucket, key)
+          .withExpiration(duration)
+          .withResponseHeaders(
+            new ResponseHeaderOverrides()
+              .withContentDisposition(s"""attachment; filename="$fileName"""")
+          )
+      )
       .leftMap(t => InternalServerError(t.getMessage))
   }
 

--- a/core/src/main/scala/com/pennsieve/aws/s3/S3ClientFactory.scala
+++ b/core/src/main/scala/com/pennsieve/aws/s3/S3ClientFactory.scala
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.pennsieve.aws.s3
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.{ AmazonS3, AmazonS3ClientBuilder }
 
 import scala.collection.concurrent.TrieMap
 
@@ -20,7 +36,9 @@ object S3ClientFactory {
   )
   def getClientForBucket(bucket: String): S3 = {
     val region = regionMappings
-      .collectFirst { case (suffix, region) if bucket.endsWith(suffix) => region }
+      .collectFirst {
+        case (suffix, region) if bucket.endsWith(suffix) => region
+      }
       .getOrElse("us-east-1")
 
     s3ClientsMap.getOrElseUpdate(region, {
@@ -29,7 +47,8 @@ object S3ClientFactory {
     })
   }
   private def createS3Client(region: String): AmazonS3 = {
-    val regionalConfig = new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
+    val regionalConfig =
+      new ClientConfiguration().withSignerOverride("AWSS3V4SignerType")
     AmazonS3ClientBuilder
       .standard()
       .withClientConfiguration(regionalConfig)

--- a/core/src/test/scala/com/pennsieve/aws/s3/S3ClientFactoryTest.scala
+++ b/core/src/test/scala/com/pennsieve/aws/s3/S3ClientFactoryTest.scala
@@ -6,29 +6,36 @@ import com.pennsieve.aws.s3.S3ClientFactory
 class S3ClientFactoryTest extends AnyFlatSpec with Matchers {
 
   "S3ClientFactory" should "return the same client for the same region (use1)" in {
-    val use1Client1 = S3ClientFactory.getClientForBucket("pennsieve-prod-storage-use1")
-    val use1Client2 = S3ClientFactory.getClientForBucket("pennsieve-prod-logs-use1")
+    val use1Client1 =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-storage-use1")
+    val use1Client2 =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-logs-use1")
 
     use1Client1 shouldBe use1Client2
   }
 
   "S3ClientFactory" should "return the same client for the same region (afs1)" in {
-    val afs1Client1 = S3ClientFactory.getClientForBucket("pennsieve-prod-storage-afs1")
-    val afsClient2 = S3ClientFactory.getClientForBucket("pennsieve-prod-logs-afs1")
+    val afs1Client1 =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-storage-afs1")
+    val afsClient2 =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-logs-afs1")
 
     afs1Client1 shouldBe afsClient2
   }
 
   it should "create a different client for a different region" in {
-    val afs1Client1 = S3ClientFactory.getClientForBucket("pennsieve-prod-storage-afs1")
-    val use1Client1 = S3ClientFactory.getClientForBucket("pennsieve-prod-storage-use1")
+    val afs1Client1 =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-storage-afs1")
+    val use1Client1 =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-storage-use1")
 
     afs1Client1 should not be use1Client1
   }
 
   it should "use the default region(us-east-1) if the bucket suffix is not mapped" in {
     val defaultClient = S3ClientFactory.getClientForBucket("unknown-bucket")
-    val expectedDefaultClient = S3ClientFactory.getClientForBucket("pennsieve-prod-storage-use11")
+    val expectedDefaultClient =
+      S3ClientFactory.getClientForBucket("pennsieve-prod-storage-use11")
 
     defaultClient shouldBe expectedDefaultClient
   }


### PR DESCRIPTION
## Changes Proposed

Deprecate the **GET** `/packages/:id/sources` endpoint as it is redundant with the **GET** `/packages/:id/sources-paged` endpoint.

[ClickUp Ticket](https://app.clickup.com/t/868adbrcp)

## Checklist

- [ ] unit tests added and/or verified that tests pass
- [ ] I have considered any possible security implications of this change
- [ ] I have considered deployment issues.
