### PR TITLE
add BDF as timeseries support

### DIFF
--- a/core-models/src/main/scala/com/pennsieve/models/FileExtensions.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/FileExtensions.scala
@@ -74,6 +74,7 @@ object FileExtensions {
     ".mef" -> FileType.MEF,
     ".mefd.gz" -> FileType.MEF3,
     ".edf" -> FileType.EDF,
+    ".bdf" -> FileType.BDF,
     ".tdm" -> FileType.TDMS,
     ".tdms" -> FileType.TDMS,
     ".lay" -> FileType.Persyst,

--- a/core-models/src/main/scala/com/pennsieve/models/FileType.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/FileType.scala
@@ -28,6 +28,7 @@ object FileType extends Enum[FileType] with CirceEnum[FileType] {
   case object PDF extends FileType
   case object MEF extends FileType
   case object EDF extends FileType
+  case object BDF extends FileType
   case object TDMS extends FileType
   case object OpenEphys extends FileType
   case object Persyst extends FileType

--- a/core-models/src/main/scala/com/pennsieve/models/FileTypeInfo.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/FileTypeInfo.scala
@@ -102,6 +102,17 @@ object FileTypeInfo {
         hasWorkflow = true,
         icon = Timeseries
       )
+    case BDF =>
+      FileTypeInfo(
+        fileType = BDF,
+        packageType = PackageType.TimeSeries,
+        packageSubtype = "Timeseries",
+        masterExtension = None,
+        grouping = Individual,
+        validate = false,
+        hasWorkflow = true,
+        icon = Timeseries
+      )
     case TDMS =>
       FileTypeInfo(
         fileType = TDMS,

--- a/core/src/test/scala/com/pennsieve/models/FileExtensionsSpec.scala
+++ b/core/src/test/scala/com/pennsieve/models/FileExtensionsSpec.scala
@@ -81,4 +81,12 @@ class FileExtensionsSpec extends AnyFlatSpec with Matchers {
 
   }
 
+  "FileTypeInfo.get" should "return correct data for BDF files" in {
+    val info = FileTypeInfo.get(FileType.BDF)
+    info.fileType shouldBe FileType.BDF
+    info.packageType shouldBe PackageType.TimeSeries
+    info.packageSubtype shouldBe "Timeseries"
+    info.icon shouldBe Icon.Timeseries
+  }
+
 }


### PR DESCRIPTION
## Changes Proposed
Adds BDF as a timeseries type to enable pickup by the timeseries ingestion process

## Checklist

- [X] unit tests added and/or verified that tests pass
- [X] I have considered any possible security implications of this change
- [X] I have considered deployment issues.
