### PR TITLE
drop `record_identifiers`

### DIFF
--- a/migrations/src/main/resources/db/organization-schema-migrations/V20250625111935__drop_record_identifiers.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20250625111935__drop_record_identifiers.sql
@@ -1,0 +1,103 @@
+ALTER TABLE records
+    ADD COLUMN key_hash TEXT;
+
+UPDATE records
+SET    key_hash = record_identifiers.key_hash
+FROM   record_identifiers
+WHERE  record_identifiers.id = records.id;
+
+CREATE UNIQUE INDEX records_model_id_key_hash_key
+     ON records (model_id, key_hash)
+  WHERE key_hash IS NOT NULL
+    AND is_current;
+
+ALTER TABLE records
+    DROP CONSTRAINT records_id_model_id_fkey,
+    DROP CONSTRAINT records_id_dataset_id_fkey;
+
+ALTER TABLE relationships
+    DROP CONSTRAINT relationships_source_record_id_fkey,
+    DROP CONSTRAINT relationships_target_record_id_fkey;
+
+DROP TRIGGER  relationships_source_target_record_id_dataset_id_check ON relationships;
+DROP FUNCTION enforce_relationships_records_dataset();
+
+CREATE FUNCTION enforce_relationships_records_dataset() RETURNS trigger AS $$
+DECLARE
+    source_record_dataset_id  INT;
+    target_record_dataset_id  INT;
+BEGIN
+  EXECUTE format(
+    'SELECT dataset_id FROM %I.records WHERE id = $1 LIMIT 1',
+    TG_TABLE_SCHEMA)
+  INTO  source_record_dataset_id
+  USING NEW.source_record_id;
+
+  IF source_record_dataset_id IS NULL THEN
+      RAISE EXCEPTION 'source_record_id % does not exist', NEW.source_record_id;
+  END IF;
+
+  EXECUTE format(
+    'SELECT dataset_id FROM %I.records WHERE id = $1 LIMIT 1',
+    TG_TABLE_SCHEMA)
+  INTO  target_record_dataset_id
+  USING NEW.target_record_id;
+
+  IF target_record_dataset_id IS NULL THEN
+      RAISE EXCEPTION 'target_record_id % does not exist', NEW.target_record_id;
+  END IF;
+
+  IF source_record_dataset_id IS DISTINCT FROM target_record_dataset_id THEN
+      RAISE EXCEPTION 'related records must belong to the same dataset';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER relationships_source_target_record_id_dataset_id_check
+BEFORE INSERT OR UPDATE ON relationships
+FOR EACH ROW EXECUTE FUNCTION enforce_relationships_records_dataset();
+
+ALTER TABLE record_packages
+    DROP CONSTRAINT record_packages_record_id_fkey;
+
+DROP TRIGGER  record_packages_dataset_check ON record_packages;
+DROP FUNCTION enforce_record_packages_dataset();
+
+CREATE FUNCTION enforce_record_packages_dataset() RETURNS trigger AS $$
+DECLARE
+    record_dataset_id INT;
+    package_dataset_id INT;
+BEGIN
+  EXECUTE format(
+    'SELECT dataset_id FROM %I.records WHERE id = $1 LIMIT 1',
+    TG_TABLE_SCHEMA)
+  INTO  record_dataset_id
+  USING NEW.record_id;
+
+  IF record_dataset_id IS NULL THEN
+      RAISE EXCEPTION 'record_id % does not exist', NEW.record_id;
+  END IF;
+
+  EXECUTE format(
+    'SELECT dataset_id FROM %I.packages WHERE id = $1 LIMIT 1',
+    TG_TABLE_SCHEMA)
+  INTO  package_dataset_id
+  USING NEW.package_id;
+
+  IF package_dataset_id IS NULL THEN
+      RAISE EXCEPTION 'package_id % does not exist', NEW.package_id;
+  END IF;
+
+  IF record_dataset_id IS DISTINCT FROM package_dataset_id THEN
+      RAISE EXCEPTION 'record and package must belong to the same dataset';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER record_packages_dataset_check
+BEFORE INSERT OR UPDATE ON record_packages
+FOR EACH ROW EXECUTE FUNCTION enforce_record_packages_dataset();
+
+DROP TABLE record_identifiers;


### PR DESCRIPTION
## Motivation
Companion to: https://github.com/Pennsieve/metadata-service/pull/4

## Testing
Ran `./build-postgres.sh` without issue:
```
...
INFO: Migrating schema "3" to version 20250625111935 - drop record identifiers
Jun 25, 2025 7:23:40 PM org.flywaydb.core.internal.command.DbMigrate logSummary
INFO: Successfully applied 111 migrations to schema "3" (execution time 00:01.039s).

Refreshing union view: files
Refreshing union view: datacanvases
WARN[0000] /Users/rohan/Code/pennsieve-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
Successfully copied 4.1kB to pennsieve-api-postgres-1:/local-seed.sql
WARN[0000] /Users/rohan/Code/pennsieve-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
 refresh_union_view
--------------------

(1 row)

INSERT 0 3
INSERT 0 2
INSERT 0 3
INSERT 0 1
INSERT 0 1
INSERT 0 1
INSERT 0 1
INSERT 0 5
WARN[0000] /Users/rohan/Code/pennsieve-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

Creating new pennsieve/pennsievedb:V20250625111935-seed from dd53817a20519d34cdc405121daf1c209bfb27e9a2f892b3f6ec1becf6b67511

WARN[0000] /Users/rohan/Code/pennsieve-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Stopping 1/1
 ✔ Container pennsieve-api-postgres-1  Stopped                                                                                                                                                                                           0.2s
sha256:e56da2c160d12714c7bdbfab38e937fd1dd18b313f210c89c3f2fb2aa75dc125
WARN[0000] /Users/rohan/Code/pennsieve-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Running 2/0
 ✔ Container pennsieve-api-postgres-1  Removed                                                                                                                                                                                           0.0s
 ✔ Network pennsieve-api_default       Removed                                                                                                                                                                                           0.0s
WARN[0000] /Users/rohan/Code/pennsieve-api/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
No stopped containers

The build-postgres script is complete.
```