### PR TITLE
Add viewer_assets Postgres tables

### DIFF
--- a/migrations/src/main/resources/db/migrations/V20260409120000__create_viewer_asset_cleanup_queue.sql
+++ b/migrations/src/main/resources/db/migrations/V20260409120000__create_viewer_asset_cleanup_queue.sql
@@ -4,5 +4,6 @@ CREATE TABLE viewer_asset_cleanup_queue (
   dataset_id  INTEGER NOT NULL,
   asset_id    UUID NOT NULL,
   s3_bucket   VARCHAR(255) NOT NULL,
+  s3_prefix   VARCHAR(512) NOT NULL,
   created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/migrations/src/main/resources/db/migrations/V20260409120000__create_viewer_asset_cleanup_queue.sql
+++ b/migrations/src/main/resources/db/migrations/V20260409120000__create_viewer_asset_cleanup_queue.sql
@@ -1,0 +1,8 @@
+CREATE TABLE viewer_asset_cleanup_queue (
+  id          SERIAL PRIMARY KEY,
+  org_id      INTEGER NOT NULL,
+  dataset_id  INTEGER NOT NULL,
+  asset_id    UUID NOT NULL,
+  s3_bucket   VARCHAR(255) NOT NULL,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20260409120000__create_viewer_assets.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20260409120000__create_viewer_assets.sql
@@ -32,11 +32,11 @@ CREATE OR REPLACE FUNCTION viewer_asset_cleanup_trigger() RETURNS TRIGGER AS $$
 BEGIN
   INSERT INTO pennsieve.viewer_asset_cleanup_queue (org_id, dataset_id, asset_id, s3_bucket, s3_prefix)
   VALUES (
-    current_schema::INTEGER,
+    TG_TABLE_SCHEMA::INTEGER,
     OLD.dataset_id,
     OLD.id,
     OLD.s3_bucket,
-    'viewer-assets/O' || current_schema || '/D' || OLD.dataset_id || '/' || OLD.id || '/'
+    'viewer-assets/O' || TG_TABLE_SCHEMA || '/D' || OLD.dataset_id || '/' || OLD.id || '/'
   );
 
   RETURN OLD;

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20260409120000__create_viewer_assets.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20260409120000__create_viewer_assets.sql
@@ -30,8 +30,14 @@ CREATE INDEX viewer_asset_packages_viewer_asset_id_idx ON viewer_asset_packages(
 
 CREATE OR REPLACE FUNCTION viewer_asset_cleanup_trigger() RETURNS TRIGGER AS $$
 BEGIN
-  INSERT INTO pennsieve.viewer_asset_cleanup_queue (org_id, dataset_id, asset_id, s3_bucket)
-  VALUES (current_schema::INTEGER, OLD.dataset_id, OLD.id, OLD.s3_bucket);
+  INSERT INTO pennsieve.viewer_asset_cleanup_queue (org_id, dataset_id, asset_id, s3_bucket, s3_prefix)
+  VALUES (
+    current_schema::INTEGER,
+    OLD.dataset_id,
+    OLD.id,
+    OLD.s3_bucket,
+    'viewer-assets/O' || current_schema || '/D' || OLD.dataset_id || '/' || OLD.id || '/'
+  );
 
   RETURN OLD;
 END;

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20260409120000__create_viewer_assets.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20260409120000__create_viewer_assets.sql
@@ -1,0 +1,42 @@
+CREATE TABLE viewer_assets (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  dataset_id  INTEGER NOT NULL REFERENCES datasets(id) ON DELETE CASCADE,
+  name        VARCHAR(255) NOT NULL,
+  asset_type  VARCHAR(255) NOT NULL,
+  properties  JSONB DEFAULT '{}',
+  s3_bucket   VARCHAR(255) NOT NULL,
+  status      VARCHAR(50) NOT NULL DEFAULT 'created',
+  created_by  INTEGER,
+  created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX viewer_assets_dataset_id_idx ON viewer_assets(dataset_id);
+
+CREATE TRIGGER viewer_assets_update_updated_at
+  BEFORE UPDATE ON viewer_assets
+  FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+CREATE TABLE viewer_asset_packages (
+  viewer_asset_id  UUID NOT NULL REFERENCES viewer_assets(id) ON DELETE CASCADE,
+  package_id       INTEGER NOT NULL REFERENCES packages(id) ON DELETE CASCADE,
+  created_at       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  PRIMARY KEY(viewer_asset_id, package_id)
+);
+
+CREATE INDEX viewer_asset_packages_package_id_idx ON viewer_asset_packages(package_id);
+CREATE INDEX viewer_asset_packages_viewer_asset_id_idx ON viewer_asset_packages(viewer_asset_id);
+
+CREATE OR REPLACE FUNCTION viewer_asset_cleanup_trigger() RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO pennsieve.viewer_asset_cleanup_queue (org_id, dataset_id, asset_id, s3_bucket)
+  VALUES (current_schema::INTEGER, OLD.dataset_id, OLD.id, OLD.s3_bucket);
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER viewer_asset_before_delete
+  BEFORE DELETE ON viewer_assets
+  FOR EACH ROW EXECUTE PROCEDURE viewer_asset_cleanup_trigger();


### PR DESCRIPTION
## Summary
- Adds `viewer_assets` table (UUID PK, dataset-scoped) and `viewer_asset_packages` N:N junction table to org-scoped schema
- Adds `viewer_asset_cleanup_queue` table to shared `pennsieve` schema
- BEFORE DELETE trigger on `viewer_assets` writes to cleanup queue for S3 object cleanup on cascading deletes

Part of the package-assets feature. Related PRs:
- Pennsieve/packages-service — CRUD endpoints + cleanup Lambda
- Pennsieve/data-target-assets — client updated to use new endpoints

## Test plan
- [ ] Run Flyway migrations against dev database
- [ ] Verify tables created in org schemas
- [ ] Verify trigger fires on DELETE and CASCADE delete from datasets
- [ ] Verify cleanup queue entries written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)