### PR TITLE
Add replaces_package_id/replaced_by_package_id to packages

### DIFF
--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -748,8 +748,14 @@ class PackageManager(datasetManager: DatasetManager) {
           """)
       else None
 
+    // Explicit column list (not p.*) so that adding columns to the packages
+    // table in future migrations does not shift the positional reads in the
+    // GetResult[(Package, Seq[File])] extractor below. Column order must
+    // match the extractor.
     sql"""
-       SELECT p.*#${selectFiles}
+       SELECT p.id, p.name, p.type, p.state, p.dataset_id, p.parent_id,
+              p.updated_at, p.created_at, p.attributes, p.node_id,
+              p.size, p.owner_id, p.import_id#${selectFiles}
        FROM "#${organization.schemaId}".packages p
        INNER JOIN (
          SELECT p.id FROM "#${organization.schemaId}".packages p

--- a/migrations/src/main/resources/db/organization-schema-migrations/V20260419000000__add_package_replaces.sql
+++ b/migrations/src/main/resources/db/organization-schema-migrations/V20260419000000__add_package_replaces.sql
@@ -1,0 +1,17 @@
+ALTER TABLE packages
+    ADD COLUMN replaces_package_id INTEGER DEFAULT NULL
+        REFERENCES packages(id) ON DELETE SET NULL,
+    ADD COLUMN replaced_by_package_id INTEGER DEFAULT NULL
+        REFERENCES packages(id) ON DELETE SET NULL,
+    ADD CONSTRAINT packages_only_files_replace
+        CHECK (replaces_package_id IS NULL OR type != 'Collection'),
+    ADD CONSTRAINT packages_only_files_replaced_by
+        CHECK (replaced_by_package_id IS NULL OR type != 'Collection');
+
+CREATE INDEX idx_packages_replaces_package_id
+    ON packages(replaces_package_id)
+    WHERE replaces_package_id IS NOT NULL;
+
+CREATE INDEX idx_packages_replaced_by_package_id
+    ON packages(replaced_by_package_id)
+    WHERE replaced_by_package_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- New per-org migration adding `replaces_package_id` and `replaced_by_package_id` self-FK columns to `packages`
- Both use `ON DELETE SET NULL` so the link clears when S3 lifecycle expiry hard-deletes the predecessor after the trash grace period
- `CHECK` constraints restrict the columns to non-Collection rows (folders are get-or-create, never replaced)
- Partial indexes on both columns (most rows never have a replacement relationship)

Foundational schema change for the upcoming replace-on-conflict upload feature. Next steps (separate PRs): `pennsieve-go-core` adds an `onConflict` param to `AddPackages`, `upload-service-v2` threads it through the manifest/finalize flow, `pennsieve-app` adds the conflict dialog + user preference.

## Test plan
- [x] `sbt migrations/test` passes
- [ ] Apply against a non-empty org schema in dev; confirm `ALTER TABLE` + index creation time is acceptable
- [ ] Verify `ON DELETE SET NULL` fires: insert two packages with a replace link, hard-delete the predecessor, confirm the surviving row's `replaces_package_id` becomes NULL
- [ ] Verify `CHECK` constraint rejects inserting/updating a Collection row with a non-null `replaces_package_id` or `replaced_by_package_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)