### PR TITLE
Gate package download endpoints on files.scan_status

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/PackagesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/PackagesController.scala
@@ -88,7 +88,10 @@ case class CreateFileRequest(
   size: Option[Long]
 )
 
-case class DownloadItemResponse(url: String)
+case class DownloadItemResponse(
+  url: String,
+  scanStatus: Option[String] = None
+)
 
 case class GetAnnotationsResponse(
   annotations: Map[Int, Seq[AnnotationDTO]],
@@ -109,6 +112,14 @@ object PackagesController {
   val FILES_LIMIT_DEFAULT: Int = 100
   val FILES_LIMIT_MAX: Int = 500
   val FILES_OFFSET_DEFAULT: Int = 0
+
+  // scan_status values that must block a presigned-URL issuance.
+  // See scan-service/docs/developer.md §12.3 (enforcement policy).
+  val ScanStatusInfected: String = "infected"
+  val ScanStatusFailed: String = "failed"
+
+  def scanStatusBlocks(scanStatus: Option[String]): Boolean =
+    scanStatus.exists(s => s == ScanStatusInfected || s == ScanStatusFailed)
 }
 
 class PackagesController(
@@ -538,44 +549,71 @@ class PackagesController(
                 Set.empty[String],
                 DownloadManifestDTO(
                   DownloadManifestHeader(0, 0L),
-                  List.empty[DownloadManifestEntry]
+                  List.empty[DownloadManifestEntry],
+                  List.empty[DownloadManifestBlockedEntry]
                 )
               )
             ) {
               case ((datasetIds, rootNodeIds, downloadResponse), p) => {
-                val newEntry: DownloadManifestEntry = DownloadManifestEntry(
-                  nodeId = p.nodeId,
-                  fileName = p.fileName,
-                  packageName = p.packageName,
-                  // append the package's own name to the path ONLY if it contains multiple files
-                  path =
-                    if (p.packageFileCount === 1)
-                      p.packageNamePath.toList
-                    else p.packageNamePath.toList :+ p.packageName,
-                  url = objectStore
-                    .getPresignedUrl(
-                      p.s3Bucket,
-                      p.s3Key,
-                      DateTime.now.plusMinutes(180).toDate,
-                      p.packageName,
-                      p.publishedS3VersionId
-                    )
-                    .toOption
-                    .get,
-                  size = p.size,
-                  fileExtension = Utilities.getFullExtension(p.s3Key)
-                )
-                (
-                  datasetIds + p.datasetId,
-                  rootNodeIds + p.nodeIdPath.headOption
-                    .getOrElse(p.nodeId),
+                // Gate on scan_status (see scan-service docs §12.3):
+                // infected/failed are routed into `blocked` with no
+                // presigned URL; anything else (clean / pending /
+                // scanning / unscanned / not_required / null) passes
+                // through to `data` with the status surfaced.
+                val newState = if (PackagesController.scanStatusBlocks(p.scanStatus)) {
+                  val blockedEntry = DownloadManifestBlockedEntry(
+                    nodeId = p.nodeId,
+                    fileName = p.fileName,
+                    packageName = p.packageName,
+                    scanStatus = p.scanStatus.getOrElse("")
+                  )
+                  DownloadManifestDTO(
+                    DownloadManifestHeader(
+                      downloadResponse.header.count,
+                      downloadResponse.header.size,
+                      Some(downloadResponse.header.blockedCount.getOrElse(0) + 1)
+                    ),
+                    downloadResponse.data,
+                    downloadResponse.blocked :+ blockedEntry
+                  )
+                } else {
+                  val newEntry: DownloadManifestEntry = DownloadManifestEntry(
+                    nodeId = p.nodeId,
+                    fileName = p.fileName,
+                    packageName = p.packageName,
+                    // append the package's own name to the path ONLY if it contains multiple files
+                    path =
+                      if (p.packageFileCount === 1)
+                        p.packageNamePath.toList
+                      else p.packageNamePath.toList :+ p.packageName,
+                    url = objectStore
+                      .getPresignedUrl(
+                        p.s3Bucket,
+                        p.s3Key,
+                        DateTime.now.plusMinutes(180).toDate,
+                        p.packageName,
+                        p.publishedS3VersionId
+                      )
+                      .toOption
+                      .get,
+                    size = p.size,
+                    fileExtension = Utilities.getFullExtension(p.s3Key),
+                    scanStatus = p.scanStatus
+                  )
                   DownloadManifestDTO(
                     DownloadManifestHeader(
                       downloadResponse.header.count + 1,
-                      downloadResponse.header.size + p.size
+                      downloadResponse.header.size + p.size,
+                      downloadResponse.header.blockedCount
                     ),
-                    downloadResponse.data :+ newEntry
+                    downloadResponse.data :+ newEntry,
+                    downloadResponse.blocked
                   )
+                }
+                (
+                  datasetIds + p.datasetId,
+                  rootNodeIds + p.nodeIdPath.headOption.getOrElse(p.nodeId),
+                  newState
                 )
               }
             }
@@ -921,7 +959,7 @@ class PackagesController(
   get("/:packageId/files/:id", operation(getFileOperation)) {
 
     new AsyncResult {
-      val s3url: EitherT[Future, ActionResult, URL] = for {
+      val result: EitherT[Future, ActionResult, DownloadItemResponse] = for {
         packageId <- paramT[String]("packageId")
         traceId <- getTraceId(request)
         fileId <- paramT[Int]("id")
@@ -939,6 +977,19 @@ class PackagesController(
 
         organization = secureContainer.organization
         file <- secureContainer.fileManager.get(fileId, pkg).orNotFound()
+
+        // Gate on scan_status: infected/failed → 403. See scan-service
+        // docs §12.3. Clean, pending, scanning, unscanned, not_required,
+        // or null (pre-migration) all fall through.
+        _ <- if (PackagesController.scanStatusBlocks(file.scanStatus))
+          EitherT.leftT[Future, Unit](
+            Forbidden(
+              Error(
+                s"file download blocked (scan_status=${file.scanStatus.getOrElse("")})"
+              )
+            ): ActionResult
+          )
+        else EitherT.rightT[Future, ActionResult](())
 
         url <- if (!short)
           objectStore
@@ -984,11 +1035,9 @@ class PackagesController(
           .toEitherT
           .coreErrorToActionResult()
 
-      } yield url
+      } yield DownloadItemResponse(url.toString, file.scanStatus)
 
-      override val is = s3url.value.map(HandleResult(_) { url =>
-        Ok(DownloadItemResponse(url.toString))
-      })
+      override val is = result.value.map(OkResult)
     }
   }
 
@@ -1037,6 +1086,19 @@ class PackagesController(
         file <- secureContainer.fileManager.get(fileIdAsInt, pkg).orNotFound()
         // TODO This is necessary since the File model no longer relies on nodeId
         // only it's ID (which is just an autoincremented int)
+
+        // Gate on scan_status: infected/failed → 403. See scan-service
+        // docs §12.3.
+        _ <- if (PackagesController.scanStatusBlocks(file.scanStatus))
+          EitherT.leftT[Future, Unit](
+            Forbidden(
+              Error(
+                s"file download blocked (scan_status=${file.scanStatus.getOrElse("")})"
+              )
+            ): ActionResult
+          )
+        else EitherT.rightT[Future, ActionResult](())
+
         _ <- auditLogger
           .message()
           .append("organization", organization.id)

--- a/core-models/src/main/scala/com/pennsieve/dtos/DownloadManifestDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/DownloadManifestDTO.scala
@@ -25,10 +25,30 @@ case class DownloadManifestEntry(
   path: List[String] = List.empty,
   url: URL,
   size: Long,
-  fileExtension: Option[String] = None
+  fileExtension: Option[String] = None,
+  // scanStatus surfaces the per-file malware-scan verdict so clients
+  // can render an in-progress indicator (pending/scanning) or pass-
+  // through label (clean/unscanned/not_required). Files with
+  // infected/failed status never appear here — they are routed into
+  // DownloadManifestDTO.blocked instead (see scan-service docs §12.3).
+  scanStatus: Option[String] = None
 )
 
-case class DownloadManifestHeader(count: Int, size: Long)
+// DownloadManifestBlockedEntry is returned for files that were
+// excluded from `data` because of a blocking scan_status. It omits
+// the presigned URL — the client should not attempt download.
+case class DownloadManifestBlockedEntry(
+  nodeId: String,
+  fileName: String,
+  packageName: String,
+  scanStatus: String
+)
+
+case class DownloadManifestHeader(
+  count: Int,
+  size: Long,
+  blockedCount: Option[Int] = None
+)
 
 case class DownloadRequest(
   nodeIds: List[String],
@@ -36,5 +56,6 @@ case class DownloadRequest(
 )
 case class DownloadManifestDTO(
   header: DownloadManifestHeader,
-  data: List[DownloadManifestEntry]
+  data: List[DownloadManifestEntry],
+  blocked: List[DownloadManifestBlockedEntry] = List.empty
 )

--- a/core-models/src/main/scala/com/pennsieve/dtos/FileContent.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/FileContent.scala
@@ -41,7 +41,13 @@ case class FileContent(
   assetType: Option[String] = None,
   provenanceId: Option[UUID] = None,
   published: Boolean = false,
-  publishedS3VersionId: Option[String] = None
+  publishedS3VersionId: Option[String] = None,
+  // scan_status from the per-org files table (see scan-service
+  // developer.md §7). UI uses this to render badges and disable the
+  // download button for 'infected' / 'failed'. Optional so this DTO
+  // tolerates pre-migration rows; in practice the migration sets a
+  // NOT NULL DEFAULT 'pending'.
+  scanStatus: Option[String] = None
 )
 
 final case class SimpleFileContent(
@@ -53,7 +59,8 @@ final case class SimpleFileContent(
   checksum: Option[FileChecksum] = None,
   id: Int,
   filename: String,
-  size: Long
+  size: Long,
+  scanStatus: Option[String] = None
 )
 
 object FileContent {

--- a/core-models/src/main/scala/com/pennsieve/dtos/FileDTO.scala
+++ b/core-models/src/main/scala/com/pennsieve/dtos/FileDTO.scala
@@ -54,7 +54,8 @@ object FileDTO {
         file.assetType,
         file.provenanceId,
         file.published,
-        file.publishedS3VersionId
+        file.publishedS3VersionId,
+        file.scanStatus
       )
     )
   }
@@ -77,7 +78,8 @@ object SimpleFileDTO {
         file.checksum,
         file.id,
         file.fileName,
-        file.size
+        file.size,
+        file.scanStatus
       )
     )
 }

--- a/core-models/src/main/scala/com/pennsieve/models/File.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/File.scala
@@ -42,11 +42,13 @@ final case class File(
   provenanceId: Option[UUID] = None,
   published: Boolean = false,
   publishedS3VersionId: Option[String] = None,
-  // scan_status TEXT NOT NULL DEFAULT 'pending' at the DB level;
-  // Option here because older read paths / older DB images may still
-  // surface NULL. Vocabulary: pending / scanning / clean /
+  // scan_status TEXT NOT NULL DEFAULT 'pending' at the DB level.
+  // Option-typed because older read paths / older DB images may still
+  // surface NULL. Default matches the DB default so File() insertions
+  // via Slick's filesSelect projection don't violate the NOT NULL
+  // constraint. Vocabulary: pending / scanning / clean /
   // format_validated / unscanned / infected / failed / not_required.
-  scanStatus: Option[String] = None,
+  scanStatus: Option[String] = Some("pending"),
   id: Int = 0
 ) {
 

--- a/core-models/src/main/scala/com/pennsieve/models/File.scala
+++ b/core-models/src/main/scala/com/pennsieve/models/File.scala
@@ -42,6 +42,11 @@ final case class File(
   provenanceId: Option[UUID] = None,
   published: Boolean = false,
   publishedS3VersionId: Option[String] = None,
+  // scan_status TEXT NOT NULL DEFAULT 'pending' at the DB level;
+  // Option here because older read paths / older DB images may still
+  // surface NULL. Vocabulary: pending / scanning / clean /
+  // format_validated / unscanned / infected / failed / not_required.
+  scanStatus: Option[String] = None,
   id: Int = 0
 ) {
 

--- a/core/src/main/scala/com/pennsieve/db/FilesTable.scala
+++ b/core/src/main/scala/com/pennsieve/db/FilesTable.scala
@@ -103,6 +103,10 @@ abstract class AbstractFilesTable[T](
   def provenanceId = column[Option[UUID]]("provenance_id")
   def published = column[Boolean]("published")
   def publishedS3VersionId = column[Option[String]]("published_s3_version_id")
+  // Read as Option to tolerate pre-migration rows / older DB images.
+  // DB default is 'pending'; see pennsieve-db-migrations
+  // V20260420120100__add_scan_status_to_files.sql.
+  def scanStatus = column[Option[String]]("scan_status")
 
   val filesSelect = (
     packageId,
@@ -123,6 +127,7 @@ abstract class AbstractFilesTable[T](
     provenanceId,
     published,
     publishedS3VersionId,
+    scanStatus,
     id
   )
 }

--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -903,7 +903,8 @@ class PackageManager(datasetManager: DatasetManager) {
     fileType: FileType,
     s3Bucket: String,
     s3Key: String,
-    publishedS3VersionId: Option[String]
+    publishedS3VersionId: Option[String],
+    scanStatus: Option[String]
   )
 
   implicit val packageHierarchy: GetResult[PackageHierarchy] =
@@ -924,6 +925,7 @@ class PackageManager(datasetManager: DatasetManager) {
       val s3Bucket = p.<<[String]
       val s3Key = p.<<[String]
       val publishedS3VersionId = p.<<?[String]
+      val scanStatus = p.<<?[String]
 
       PackageHierarchy(
         datasetId,
@@ -941,7 +943,8 @@ class PackageManager(datasetManager: DatasetManager) {
         FileType.withName(fileType),
         s3Bucket,
         s3Key,
-        publishedS3VersionId
+        publishedS3VersionId,
+        scanStatus
       )
     }
 
@@ -1004,7 +1007,8 @@ class PackageManager(datasetManager: DatasetManager) {
                 f.file_type,
                 f.s3_bucket,
                 f.s3_key,
-                f.published_s3_version_id
+                f.published_s3_version_id,
+                f.scan_status
               FROM
                 parents
               JOIN "#${organization.schemaId}".files f ON
@@ -1091,7 +1095,8 @@ class PackageManager(datasetManager: DatasetManager) {
                 f.file_type,
                 f.s3_bucket,
                 f.s3_key,
-                f.published_s3_version_id
+                f.published_s3_version_id,
+                f.scan_status
               FROM
                 parents
               JOIN "#${orgId}".files f ON

--- a/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/PackageManagerSpec.scala
@@ -1521,7 +1521,9 @@ class PackageManagerSpec extends BaseManagerSpec {
         fileType = rootFile.fileType,
         s3Bucket = rootFile.s3Bucket,
         s3Key = rootFile.s3Key,
-        publishedS3VersionId = rootFile.publishedS3VersionId
+        publishedS3VersionId = rootFile.publishedS3VersionId,
+        // files.scan_status DB default is 'pending' (migration V20260420120100)
+        scanStatus = Some("pending")
       ),
       pm.PackageHierarchy(
         datasetId = dataset.id,
@@ -1539,7 +1541,8 @@ class PackageManagerSpec extends BaseManagerSpec {
         fileType = unpublishedChildFile.fileType,
         s3Bucket = unpublishedChildFile.s3Bucket,
         s3Key = unpublishedChildFile.s3Key,
-        publishedS3VersionId = unpublishedChildFile.publishedS3VersionId
+        publishedS3VersionId = unpublishedChildFile.publishedS3VersionId,
+        scanStatus = Some("pending")
       ),
       pm.PackageHierarchy(
         datasetId = dataset.id,
@@ -1557,7 +1560,8 @@ class PackageManagerSpec extends BaseManagerSpec {
         fileType = publishedChildFile.fileType,
         s3Bucket = publishedChildFile.s3Bucket,
         s3Key = publishedChildFile.s3Key,
-        publishedS3VersionId = publishedChildFile.publishedS3VersionId
+        publishedS3VersionId = publishedChildFile.publishedS3VersionId,
+        scanStatus = Some("pending")
       )
     )
 


### PR DESCRIPTION
## Summary
Phase-3a enforcement for pennsieve-api. Companion to packages-service #56 (Go `/download-manifest`, **merged**) — this PR ports the same gating to the three Scala presign endpoints. Together they make `scan_status` actually load-bearing rather than observational.

Three presign routes now read `scan_status` from the per-org `files` table and behave as:
- `infected` / `failed` → 403 Forbidden (no URL issued)
- `pending` / `scanning` / `clean` / `format_validated` / `unscanned` / `not_required` / `null` → 200 with URL + `scanStatus` surfaced

Routes affected:
- `GET /:packageId/files/:id` — returns `DownloadItemResponse` (now includes `scanStatus`)
- `GET /:packageId/files/:id/presign/*` (regex variant) — 403 or redirect to presigned URL
- `POST /download-manifest` (bulk) — blocked files routed into a new `DownloadManifestDTO.blocked` array (`header.blockedCount` surfaces the count); existing consumers reading only `data` continue to work

## Schema changes
- `File` case class: new `scanStatus: Option[String]` (DB column is NOT NULL DEFAULT 'pending', `Option` tolerates pre-migration rows)
- `FilesTable` / `filesSelect` / `AllFilesView`: include `scan_status`
- `PackageHierarchy` case class + `GetResult` + both recursive-CTE SELECTs in `PackageManager`: include `scan_status`
- `DownloadItemResponse`: new `scanStatus: Option[String]`
- `DownloadManifestEntry`: new `scanStatus: Option[String]`
- `DownloadManifestHeader`: new `blockedCount: Option[Int]`
- New `DownloadManifestBlockedEntry` case class
- `DownloadManifestDTO`: new `blocked: List[DownloadManifestBlockedEntry]`

## Audited downstream consumers (no change required)
- **zipit-service** (TypeScript): loose JSONStream + Yup `.shape()` — silently ignores the new top-level `blocked` array and `scanStatus` entries.
- **compute-node-aws-provisioner-v2** workflow-init + data-transfer (Go): struct-tagged `json.Unmarshal` drops unknown fields. workflow-init will silently drop blocked files from its EFS manifest; a follow-up log message is planned but not blocking.

## Rebase notes (2026-05-05)
This PR has been **rebased onto current main**. The original branch had four commits; two are now obsolete and have been dropped:

| Original | Fate |
|---|---|
| Add scan_status columns to bundled org-schema migrations | **DROPPED** — PR #378 ripped out the bundled-migrations system; the migration lives authoritatively in pennsieve-db-migrations |
| Bump test pennsievedb image to V20260420120100 | **DROPPED** — main now uses the floating `pennsieve/pennsievedb:latest-seed` tag (PR #378), which already includes `V20260420120100` from pennsieve-db-migrations main |
| Fix PackageHierarchy test arity + default scanStatus | **KEPT** |
| Gate package download endpoints on files.scan_status | **KEPT** (the actual feature) |

So the PR is now 2 commits, both pure code changes, no schema or test-infra plumbing.

## Test plan
- [x] Cherry-picks applied with no conflicts
- [ ] Jenkins CI pass (kicked off on this push)
- [ ] One reviewer
- [ ] Deploy to dev; verify a known-`infected` file 403s on `/packages/{id}/files/{id}` and lands in `blocked[]` on `/download-manifest`; verify `scanStatus` surfaces on `clean` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)