### PR TITLE
mock managers and convert APITokenControllerSpec to unit tests

### DIFF
--- a/api/src/test/scala/com/pennsieve/api/APITokenControllerSpecs.scala
+++ b/api/src/test/scala/com/pennsieve/api/APITokenControllerSpecs.scala
@@ -16,21 +16,77 @@
 
 package com.pennsieve.api
 
-import com.pennsieve.aws.cognito.MockCognito
-import com.pennsieve.domain.NotFound
+import com.pennsieve.auth.middleware.CognitoSession
 import com.pennsieve.dtos.{ APITokenDTO, APITokenSecretDTO }
-import com.pennsieve.managers.SecureTokenManager
-import com.pennsieve.models.DBPermission.Administer
+import com.pennsieve.models.{ CognitoId, Organization, Token, User }
 import org.json4s.jackson.JsonMethods._
 import org.json4s.jackson.Serialization.write
-import org.scalatest.EitherValues._
+import org.scalatest.OptionValues._
 
-class APITokenControllerSpecs extends BaseApiTest {
-  val mockCognito: MockCognito = new MockCognito()
+import java.time.Instant
+import java.util.UUID
 
-  override def afterStart(): Unit = {
-    super.afterStart()
+class APITokenControllerSpecs extends BaseApiUnitTest {
 
+  private val loggedInUser: User = User(
+    nodeId = "N:user:00000000-0000-0000-0000-000000000001",
+    email = "user@test.com",
+    firstName = "Test",
+    middleInitial = None,
+    lastName = "User",
+    degree = None,
+    credential = "",
+    color = "",
+    url = "",
+    isSuperAdmin = false,
+    id = 1
+  )
+
+  private val externalUser: User = User(
+    nodeId = "N:user:00000000-0000-0000-0000-000000000002",
+    email = "external@test.com",
+    firstName = "External",
+    middleInitial = None,
+    lastName = "User",
+    degree = None,
+    credential = "",
+    color = "",
+    url = "",
+    isSuperAdmin = false,
+    id = 2
+  )
+
+  private val loggedInOrganization: Organization = Organization(
+    nodeId = "N:organization:00000000-0000-0000-0000-000000000001",
+    name = "Test Organization",
+    slug = "test-organization",
+    encryptionKeyId = Some("test-key"),
+    id = 1
+  )
+
+  private val externalOrganization: Organization = Organization(
+    nodeId = "N:organization:00000000-0000-0000-0000-000000000002",
+    name = "External Organization",
+    slug = "external-organization",
+    encryptionKeyId = Some("test-key-2"),
+    id = 2
+  )
+
+  private val pennsieve: Organization = Organization(
+    nodeId = "N:organization:00000000-0000-0000-0000-000000000003",
+    name = "Pennsieve",
+    slug = "pennsieve",
+    encryptionKeyId = Some("test-key-3"),
+    id = 3
+  )
+
+  private var apiToken: Token = _
+  private var loggedInJwt: String = _
+  private var apiJwt: String = _
+  private var externalJwt: String = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
     addServlet(
       new APITokenController(
         insecureContainer,
@@ -40,6 +96,52 @@ class APITokenControllerSpecs extends BaseApiTest {
       ),
       "/*"
     )
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    state.users.clear()
+    state.organizations.clear()
+    state.tokens.clear()
+    mockCognito.reset()
+
+    state.users.put(loggedInUser.id, loggedInUser)
+    state.users.put(externalUser.id, externalUser)
+    state.organizations.put(loggedInOrganization.id, loggedInOrganization)
+    state.organizations.put(externalOrganization.id, externalOrganization)
+    state.organizations.put(pennsieve.id, pennsieve)
+
+    apiToken = seedToken(
+      name = "test api token",
+      userId = loggedInUser.id,
+      organizationId = loggedInOrganization.id
+    )
+
+    loggedInJwt = mintUserJwt(loggedInUser, loggedInOrganization)
+    externalJwt = mintUserJwt(externalUser, externalOrganization)
+    apiJwt = mintUserJwt(
+      loggedInUser,
+      loggedInOrganization,
+      cognito = CognitoSession
+        .API(CognitoId.TokenPoolId.randomId(), Instant.now().plusSeconds(60))
+    )
+  }
+
+  private def seedToken(
+    name: String,
+    userId: Int,
+    organizationId: Int
+  ): Token = {
+    val token = Token(
+      name = name,
+      token = UUID.randomUUID.toString,
+      cognitoId = CognitoId.TokenPoolId.randomId(),
+      organizationId = organizationId,
+      userId = userId,
+      id = state.newId()
+    )
+    state.tokens.put(token.token, token)
+    token
   }
 
   test("requests should short-circuit if using a non-browser JWT") {
@@ -60,35 +162,28 @@ class APITokenControllerSpecs extends BaseApiTest {
   test("should create an API token") {
     postJson(
       "/",
-      write(CreateTokenRequest("test api token")),
+      write(CreateTokenRequest("new api token")),
       headers = authorizationHeader(loggedInJwt)
     ) {
       val response = parse(body).extract[APITokenSecretDTO]
 
       status should be(201)
-      response.name should be("test api token")
+      response.name should be("new api token")
 
       mockCognito.sentTokenInvites.length should be(1)
 
-      val secureTokenManager =
-        new SecureTokenManager(loggedInUser, insecureContainer.db)
-      val token = secureTokenManager.get(response.key).await.value
-
-      token.userId should be(loggedInUser.id)
-
+      val stored = state.tokens.get(response.key).value
+      stored.userId should be(loggedInUser.id)
+      stored.organizationId should be(loggedInOrganization.id)
     }
   }
 
   test("should get all user's API tokens") {
-    val (apiTokenTwo, secret) = tokenManager
-      .create(
-        "test api token 2",
-        loggedInUser,
-        loggedInOrganization,
-        mockCognito
-      )
-      .await
-      .value
+    val apiTokenTwo = seedToken(
+      name = "test api token 2",
+      userId = loggedInUser.id,
+      organizationId = loggedInOrganization.id
+    )
 
     get("/", headers = authorizationHeader(loggedInJwt)) {
       val result = parse(body).extract[List[APITokenDTO]]
@@ -109,17 +204,18 @@ class APITokenControllerSpecs extends BaseApiTest {
   }
 
   test("should not get user's API tokens from another organization") {
-    val (pennsieveToken, secret) = tokenManager
-      .create("pennsieve api token", loggedInUser, pennsieve, mockCognito)
-      .await
-      .value
+    seedToken(
+      name = "pennsieve api token",
+      userId = loggedInUser.id,
+      organizationId = pennsieve.id
+    )
 
     get("/", headers = authorizationHeader(loggedInJwt)) {
       val result = parse(body).extract[List[APITokenDTO]]
 
       status should be(200)
       result.length should be(1)
-      result.map(_.key) should contain only (apiToken.token)
+      result.map(_.key) should contain only apiToken.token
     }
   }
 
@@ -136,10 +232,7 @@ class APITokenControllerSpecs extends BaseApiTest {
       status should be(200)
       result.name should equal("updated name")
 
-      val secureTokenManager =
-        new SecureTokenManager(loggedInUser, insecureContainer.db)
-      val token = secureTokenManager.get(apiToken.token).await.value
-      token.name should be("updated name")
+      state.tokens.get(apiToken.token).value.name should be("updated name")
     }
   }
 
@@ -158,33 +251,19 @@ class APITokenControllerSpecs extends BaseApiTest {
   test("should delete a user's API Token") {
     val uuid = apiToken.token
 
-    delete(s"/${uuid}", headers = authorizationHeader(loggedInJwt)) {
+    delete(s"/$uuid", headers = authorizationHeader(loggedInJwt)) {
       status should be(200)
-
-      val secureTokenManager =
-        new SecureTokenManager(loggedInUser, insecureContainer.db)
 
       mockCognito.sentDeletes.length should be(1)
 
-      secureTokenManager.get(uuid).await.left.value should equal(
-        NotFound(s"Token ($uuid)")
-      )
-      tokenManager.get(uuid).await.left.value should equal(
-        NotFound(s"Token ($uuid)")
-      )
+      state.tokens.get(uuid) should be(None)
     }
   }
 
   test("should not delete another user's API Token") {
     delete(s"/${apiToken.token}", headers = authorizationHeader(externalJwt)) {
       status should be(500)
-
-      get("/", headers = authorizationHeader(loggedInJwt)) {
-        val result = parse(body).extract[List[APITokenDTO]]
-
-        status should be(200)
-        result.map(_.key) should contain(apiToken.token)
-      }
+      state.tokens.get(apiToken.token) should be(defined)
     }
   }
 }

--- a/api/src/test/scala/com/pennsieve/api/BaseApiUnitTest.scala
+++ b/api/src/test/scala/com/pennsieve/api/BaseApiUnitTest.scala
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.api
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKitBase
+import cats.implicits._
+import com.pennsieve.aws.cognito.MockCognito
+import com.pennsieve.aws.email.LocalEmailContainer
+import com.pennsieve.aws.queue.LocalSQSContainer
+import com.pennsieve.aws.sns.{ LocalSNSContainer, SNSContainer }
+import com.pennsieve.auth.middleware.{
+  CognitoSession,
+  EncryptionKeyId,
+  Jwt,
+  OrganizationId,
+  OrganizationNodeId,
+  UserClaim,
+  UserId
+}
+import com.pennsieve.auth.middleware.Jwt.Role.RoleIdentifier
+import com.pennsieve.core.utilities.{
+  ChangelogContainer,
+  DatasetPublicationStatusContainer,
+  _
+}
+import com.pennsieve.helpers.APIContainers.{
+  InsecureAPIContainer,
+  SecureAPIContainer,
+  SecureContainerBuilderType
+}
+import com.pennsieve.helpers.fakes.{
+  FakeSecureOrganizationManager,
+  FakeSecureTokenManager,
+  FakeUserManager,
+  InMemoryState
+}
+import com.pennsieve.helpers.{
+  ApiSNSContainer,
+  ApiSQSContainer,
+  MockSNSContainer
+}
+import com.pennsieve.managers.{
+  SecureOrganizationManager,
+  SecureTokenManager,
+  UserManager
+}
+import com.pennsieve.models.{ CognitoId, Organization, Role, User }
+import com.pennsieve.traits.PostgresProfile.api._
+import com.pennsieve.traits.TimeSeriesDBContainer
+import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
+import org.json4s.jackson.JsonMethods._
+import org.json4s.{ DefaultFormats, Formats }
+import org.scalatest.OptionValues._
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatra.swagger.Swagger
+import org.scalatra.test.scalatest.ScalatraSuite
+import shapeless.syntax.inject._
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+/**
+  * Base for **unit** tests of API controllers. Brings up Scalatra against a
+  * fake-backed `InsecureAPIContainer` / `SecureAPIContainer`. No Postgres,
+  * no LocalStack, no Docker.
+  *
+  * Persistence: in-memory `state`, mutated via fakes. The `db: Database`
+  * passed into the cake is a Slick `Database` pointing at an unreachable URL
+  * — Slick is lazy, so the object constructs fine but any actual `db.run(...)`
+  * call would fail at connection time. The fakes override every method that
+  * production hits, so `db` is never accessed in well-behaved tests.
+  *
+  * If a test path you didn't anticipate calls a manager method that isn't
+  * stubbed, the fake's trait body falls through to `db.run(...)` and the fake
+  * throws a clear "method not stubbed" message — that loud failure is the
+  * point.
+  */
+trait BaseApiUnitTest
+    extends AnyFunSuite
+    with ScalatraSuite
+    with TestKitBase
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll {
+
+  implicit lazy val system: ActorSystem = ActorSystem("ApiUnitTest")
+  implicit lazy val ec: ExecutionContext = system.dispatcher
+
+  implicit lazy val jwtConfig: Jwt.Config = new Jwt.Config {
+    override def key = "testkey"
+  }
+
+  implicit val swagger: Swagger = new com.pennsieve.web.SwaggerApp
+
+  protected implicit val jsonFormats: Formats = DefaultFormats
+
+  protected val state: InMemoryState = new InMemoryState
+
+  /** Phantom Slick Database — never connects, used only to satisfy the
+    * cake's `_db` parameter. Any `.run(...)` against it would throw at
+    * connection time; fakes intercept all manager methods so this never
+    * actually runs in tests. */
+  protected lazy val phantomDb: Database =
+    Database.forURL(
+      url = "jdbc:postgresql://nowhere.invalid:1/none",
+      driver = "org.postgresql.Driver"
+    )
+
+  protected lazy val config: Config = ConfigFactory
+    .empty()
+    .withValue("postgres.host", ConfigValueFactory.fromAnyRef("nowhere"))
+    .withValue("postgres.port", ConfigValueFactory.fromAnyRef(1))
+    .withValue("postgres.database", ConfigValueFactory.fromAnyRef("none"))
+    .withValue("postgres.user", ConfigValueFactory.fromAnyRef("u"))
+    .withValue("postgres.password", ConfigValueFactory.fromAnyRef("p"))
+    .withValue("data.postgres.host", ConfigValueFactory.fromAnyRef("nowhere"))
+    .withValue("data.postgres.port", ConfigValueFactory.fromAnyRef(1))
+    .withValue("data.postgres.database", ConfigValueFactory.fromAnyRef("none"))
+    .withValue("data.postgres.user", ConfigValueFactory.fromAnyRef("u"))
+    .withValue("data.postgres.password", ConfigValueFactory.fromAnyRef("p"))
+    .withValue("environment", ConfigValueFactory.fromAnyRef("local"))
+    .withValue("email.host", ConfigValueFactory.fromAnyRef("test"))
+    .withValue(
+      "email.support_email",
+      ConfigValueFactory.fromAnyRef("test@test")
+    )
+    .withValue("discover_app.host", ConfigValueFactory.fromAnyRef("disc"))
+    .withValue("sqs.host", ConfigValueFactory.fromAnyRef("http://localhost"))
+    .withValue("sqs.queue", ConfigValueFactory.fromAnyRef("http://localhost/q"))
+    .withValue(
+      "sqs.queue_v2",
+      ConfigValueFactory.fromAnyRef("http://localhost/q2")
+    )
+    .withValue("sqs.region", ConfigValueFactory.fromAnyRef("us-east-1"))
+    .withValue("sns.topic", ConfigValueFactory.fromAnyRef("test-topic"))
+    .withValue(
+      "pennsieve.changelog.sns_topic",
+      ConfigValueFactory.fromAnyRef("test-topic")
+    )
+    .withValue(
+      "pennsieve.uploads.queue",
+      ConfigValueFactory.fromAnyRef("http://localhost/uploads")
+    )
+    .withValue(
+      "pennsieve.api_host",
+      ConfigValueFactory.fromAnyRef("http://localhost")
+    )
+    .withValue(
+      "pennsieve.job_scheduling_service.host",
+      ConfigValueFactory.fromAnyRef("http://localhost")
+    )
+    .withValue(
+      "pennsieve.job_scheduling_service.queue_size",
+      ConfigValueFactory.fromAnyRef(100)
+    )
+    .withValue(
+      "pennsieve.job_scheduling_service.rate_limit",
+      ConfigValueFactory.fromAnyRef(10)
+    )
+    .withValue(
+      "pennsieve.packages_pagination.default_page_size",
+      ConfigValueFactory.fromAnyRef(1)
+    )
+    .withValue(
+      "pennsieve.packages_pagination.max_page_size",
+      ConfigValueFactory.fromAnyRef(1000)
+    )
+    .withValue(
+      "pennsieve.publishing.default_workflow",
+      ConfigValueFactory.fromAnyRef("5")
+    )
+    .withValue("jwt.key", ConfigValueFactory.fromAnyRef("testkey"))
+    .withValue("jwt.duration", ConfigValueFactory.fromAnyRef("60 seconds"))
+
+  protected lazy val mockCognito: MockCognito = new MockCognito()
+
+  protected lazy val insecureContainer: InsecureAPIContainer = {
+    val st = state
+    new InsecureContainer(config) with InsecureCoreContainer
+    with LocalEmailContainer with MessageTemplatesContainer with DataDBContainer
+    with TimeSeriesDBContainer with LocalSQSContainer with MockSNSContainer
+    with ApiSNSContainer with ApiSQSContainer {
+      override val postgresUseSSL = false
+      override val dataPostgresUseSSL = false
+      override lazy val db: Database = phantomDb
+      override lazy val dataDB: Database = phantomDb
+      override lazy val userManager: UserManager = new FakeUserManager(st)
+      override lazy val organizationManager: SecureOrganizationManager =
+        new FakeSecureOrganizationManager(st, User.serviceUser())
+      override lazy val tokenManager: SecureTokenManager =
+        new FakeSecureTokenManager(st, User.serviceUser())
+    }
+  }
+
+  protected lazy val secureContainerBuilder: SecureContainerBuilderType = {
+    (u, org) =>
+      val st = state
+      new SecureContainer(
+        config = config,
+        _db = phantomDb,
+        user = u,
+        organization = org
+      ) with SecureCoreContainer with LocalEmailContainer with MockSNSContainer
+      with ChangelogContainer with DatasetPublicationStatusContainer {
+        override val postgresUseSSL = false
+        override val dataPostgresUseSSL = false
+        override lazy val userManager: UserManager = new FakeUserManager(st)
+        override lazy val organizationManager: SecureOrganizationManager =
+          new FakeSecureOrganizationManager(st, u)
+        override lazy val tokenManager: SecureTokenManager =
+          new FakeSecureTokenManager(st, u)
+      }
+  }
+
+  /**
+    * Mint a JWT directly without any DB lookup. The role is fabricated to
+    * include just enough for downstream auth checks.
+    */
+  protected def mintUserJwt(
+    user: User,
+    organization: Organization,
+    cognito: CognitoSession =
+      CognitoSession.Browser(CognitoId.UserPoolId.randomId(),
+        Instant.now().plusSeconds(60)),
+    role: Role = Role.Owner,
+    duration: FiniteDuration = 60.seconds
+  ): String = {
+    val orgRole = Jwt.OrganizationRole(
+      OrganizationId(organization.id)
+        .inject[Jwt.Role.RoleIdentifier[OrganizationId]],
+      role,
+      organization.encryptionKeyId.map(EncryptionKeyId),
+      OrganizationNodeId(organization.nodeId).some,
+      Some(Nil)
+    )
+    val claim = Jwt.generateClaim(
+      UserClaim(
+        id = UserId(user.id),
+        roles = List(orgRole),
+        cognito = Some(cognito)
+      ),
+      duration
+    )
+    Jwt.generateToken(claim).value
+  }
+
+  protected def authorizationHeader(jwt: String): Map[String, String] =
+    Map("Authorization" -> s"Bearer $jwt")
+
+  protected val contentTypeApplicationJsonHeader: (String, String) =
+    "Content-Type" -> "application/json"
+
+  protected def postJson[A](
+    uri: String,
+    body: String,
+    headers: Map[String, String] = Map()
+  )(
+    f: => A
+  ): A =
+    post(
+      uri,
+      body.getBytes("utf-8"),
+      headers = headers + contentTypeApplicationJsonHeader
+    )(f)
+
+  protected def putJson[A](
+    uri: String,
+    body: String = "",
+    headers: Map[String, String] = Map()
+  )(
+    f: => A
+  ): A =
+    put(
+      uri,
+      body.getBytes("utf-8"),
+      headers = headers + contentTypeApplicationJsonHeader
+    )(f)
+
+  override def afterAll(): Unit = {
+    shutdown(system)
+    super.afterAll()
+  }
+}

--- a/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
@@ -24,7 +24,7 @@ import com.pennsieve.db.UserInvitesMapper
 import com.pennsieve.dtos.{ DatasetStatusDTO, TeamDTO, UserDTO, UserInviteDTO }
 import com.pennsieve.managers.{
   DatasetStatusManager,
-  SecureOrganizationManager,
+  SecureOrganizationManagerImpl,
   UpdateOrganization
 }
 import com.pennsieve.models.DBPermission.{ Administer, Delete, Owner }
@@ -613,7 +613,7 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
       headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
     ) {
       // make sure user has permission
-      new SecureOrganizationManager(secureContainer.db, colleagueUser)
+      new SecureOrganizationManagerImpl(secureContainer.db, colleagueUser)
         .hasPermission(loggedInOrganization, Administer)
         .await
         .value
@@ -631,7 +631,7 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
       headers = authorizationHeader(loggedInJwt) ++ traceIdHeader()
     ) {
       // make sure user has permission
-      new SecureOrganizationManager(secureContainer.db, integrationUser)
+      new SecureOrganizationManagerImpl(secureContainer.db, integrationUser)
         .hasPermission(loggedInOrganization, Administer)
         .await
         .value

--- a/api/src/test/scala/com/pennsieve/helpers/TestContainer.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/TestContainer.scala
@@ -27,7 +27,7 @@ import com.pennsieve.traits.PostgresProfile.api._
 import scala.concurrent.{ ExecutionContext, Future }
 
 class TestableSecureOrganizationManager(user: User, db: Database)
-    extends SecureOrganizationManager(db, user) {
+    extends SecureOrganizationManagerImpl(db, user) {
 
   override def schemaExists(
     organization: Organization
@@ -42,6 +42,6 @@ class TestableSecureOrganizationManager(user: User, db: Database)
 }
 
 trait TestCoreContainer extends InsecureCoreContainer { self: Container =>
-  override lazy val userManager: UserManager = new UserManager(db)
-  override lazy val tokenManager: TokenManager = new TokenManager(db)
+  override lazy val userManager: UserManager = new UserManagerImpl(db)
+  override lazy val tokenManager: TokenManager = new TokenManagerImpl(db)
 }

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeOrganizationManagerContainer.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeOrganizationManagerContainer.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.core.utilities.OrganizationManagerContainer
+import com.pennsieve.managers.{ OrganizationManager, SecureOrganizationManager }
+import com.pennsieve.models.User
+
+trait FakeOrganizationManagerContainer extends OrganizationManagerContainer {
+  def state: InMemoryState
+  def actor: User
+  lazy val organizationManager: OrganizationManager =
+    new FakeSecureOrganizationManager(state, actor)
+}
+
+trait FakeSecureOrganizationManagerContainer
+    extends FakeOrganizationManagerContainer {
+  override lazy val organizationManager: SecureOrganizationManager =
+    new FakeSecureOrganizationManager(state, actor)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeSecureOrganizationManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeSecureOrganizationManager.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import cats.data.EitherT
+import com.pennsieve.domain.{ CoreError, NotFound, PermissionError }
+import com.pennsieve.managers.SecureOrganizationManager
+import com.pennsieve.models.{
+  DBPermission,
+  Feature,
+  FeatureFlag,
+  Organization,
+  OrganizationUser,
+  User
+}
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+  * Backed by InMemoryState. Override only the methods a test uses; any other
+  * method will hit the trait's concrete implementation, call `db`, and fail
+  * loudly with a clear message — that loud failure is the point.
+  */
+class FakeSecureOrganizationManager(state: InMemoryState, val actor: User)
+    extends SecureOrganizationManager {
+
+  def db: Database =
+    sys.error(
+      "FakeSecureOrganizationManager: a method not yet stubbed by your test " +
+        "tried to use the database. Override the method on this fake (or a " +
+        "subclass) to add the behavior your test needs."
+    )
+
+  override def get(
+    id: Int
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Organization] =
+    state.organizations.get(id) match {
+      case Some(org) => EitherT.rightT(org)
+      case None => EitherT.leftT(NotFound(s"Organization ($id)"))
+    }
+
+  override def getByNodeId(
+    nodeId: String
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Organization] =
+    state.organizations.values.find(_.nodeId == nodeId) match {
+      case Some(org) => EitherT.rightT(org)
+      case None => EitherT.leftT(NotFound(nodeId))
+    }
+
+  override def hasPermission(
+    organization: Organization,
+    permission: DBPermission
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Unit] =
+    if (actor.isSuperAdmin) EitherT.rightT(())
+    else
+      state.orgUserPermissions.get((organization.id, actor.id)) match {
+        case Some(p) if p >= permission => EitherT.rightT(())
+        case _ =>
+          EitherT.leftT(
+            PermissionError(actor.nodeId, permission, organization.nodeId)
+          )
+      }
+
+  override def getActiveFeatureFlags(
+    organizationId: Int
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Seq[FeatureFlag]] =
+    EitherT.rightT(Seq.empty)
+
+  override def hasFeatureFlagEnabled(
+    organizationId: Int,
+    feature: Feature
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Boolean] =
+    EitherT.rightT(false)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeTokenManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeTokenManager.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import cats.data.EitherT
+import cats.implicits._
+import com.pennsieve.aws.cognito.CognitoClient
+import com.pennsieve.domain.{
+  CoreError,
+  NotFound,
+  PermissionError,
+  ThrowableError
+}
+import com.pennsieve.managers.SecureTokenManager
+import com.pennsieve.models.DBPermission.{ Read, Write }
+import com.pennsieve.models.{ Organization, Token, TokenSecret, User }
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+import java.util.UUID
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+  * In-memory fake for SecureTokenManager. State lives in InMemoryState.tokens
+  * keyed by token-string (the UUID); permission checks mirror the real
+  * SecureTokenManager (only the actor can read/update/delete their own
+  * tokens, and tokens can only be created on behalf of the actor).
+  */
+class FakeSecureTokenManager(state: InMemoryState, val actor: User)
+    extends SecureTokenManager {
+
+  def db: Database =
+    sys.error(
+      "FakeSecureTokenManager: a method not yet stubbed by your test tried " +
+        "to use the database. Override the method on this fake."
+    )
+
+  override def create(
+    name: String,
+    user: User,
+    organization: Organization,
+    cognitoClient: CognitoClient
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, (Token, TokenSecret)] = {
+    if (user.id != actor.id)
+      EitherT.leftT(PermissionError(actor.nodeId, Write, ""))
+    else {
+      val tokenString = UUID.randomUUID.toString
+      val secret = TokenSecret(UUID.randomUUID.toString)
+      EitherT(
+        cognitoClient
+          .createClientToken(tokenString, secret, organization)
+          .map { cognitoId =>
+            val token = Token(
+              name = name,
+              token = tokenString,
+              cognitoId = cognitoId,
+              organizationId = organization.id,
+              userId = user.id,
+              id = state.newId()
+            )
+            state.tokens.put(tokenString, token)
+            Right((token, secret)): Either[CoreError, (Token, TokenSecret)]
+          }
+          .recover { case t => Left(ThrowableError(t)) }
+      )
+    }
+  }
+
+  override def get(
+    user: User,
+    organization: Organization
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, List[Token]] =
+    EitherT.rightT(
+      state.tokens.values
+        .filter(t => t.userId == user.id && t.organizationId == organization.id)
+        .toList
+    )
+
+  override def get(
+    uuid: String
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Token] =
+    state.tokens.get(uuid) match {
+      case Some(t) if t.userId == actor.id => EitherT.rightT(t)
+      case Some(t) =>
+        EitherT.leftT(PermissionError(actor.nodeId, Read, t.token))
+      case None => EitherT.leftT(NotFound(s"Token ($uuid)"))
+    }
+
+  override def update(
+    token: Token
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Token] =
+    if (token.userId != actor.id)
+      EitherT.leftT(PermissionError(actor.nodeId, Read, token.token))
+    else {
+      state.tokens.put(token.token, token)
+      EitherT.rightT(token)
+    }
+
+  override def delete(
+    token: Token,
+    cognitoClient: CognitoClient
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, Int] =
+    if (token.userId != actor.id)
+      EitherT.leftT(PermissionError(actor.nodeId, Read, token.token))
+    else
+      EitherT(
+        cognitoClient
+          .deleteClientToken(token.token)
+          .map { _ =>
+            state.tokens.remove(token.token)
+            Right(1): Either[CoreError, Int]
+          }
+          .recover { case t => Left(ThrowableError(t)) }
+      )
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeTokenManagerContainer.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeTokenManagerContainer.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.core.utilities.TokenManagerContainer
+import com.pennsieve.managers.{ SecureTokenManager, TokenManager }
+import com.pennsieve.models.User
+
+trait FakeTokenManagerContainer extends TokenManagerContainer {
+  def state: InMemoryState
+  def actor: User
+  lazy val tokenManager: TokenManager =
+    new FakeSecureTokenManager(state, actor)
+}
+
+trait FakeSecureTokenManagerContainer extends FakeTokenManagerContainer {
+  override lazy val tokenManager: SecureTokenManager =
+    new FakeSecureTokenManager(state, actor)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeUserManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeUserManager.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import cats.data.EitherT
+import com.pennsieve.domain.{ CoreError, NotFound }
+import com.pennsieve.managers.UserManager
+import com.pennsieve.models.User
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+class FakeUserManager(state: InMemoryState) extends UserManager {
+
+  def db: Database =
+    sys.error(
+      "FakeUserManager: a method not yet stubbed by your test tried to use " +
+        "the database. Override the method on this fake."
+    )
+
+  override def get(
+    id: Int
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, User] =
+    state.users.get(id) match {
+      case Some(u) => EitherT.rightT(u)
+      case None => EitherT.leftT(NotFound(s"User ($id)"))
+    }
+
+  override def getByEmail(
+    email: String
+  )(implicit
+    ec: ExecutionContext
+  ): EitherT[Future, CoreError, User] =
+    state.users.values.find(_.email.equalsIgnoreCase(email)) match {
+      case Some(u) => EitherT.rightT(u)
+      case None => EitherT.leftT(NotFound(s"User ($email)"))
+    }
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/InMemoryState.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/InMemoryState.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.models.{
+  DBPermission,
+  Organization,
+  OrganizationUser,
+  Token,
+  User
+}
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.concurrent.TrieMap
+
+/**
+  * Shared in-memory state that fake managers read from and write to.
+  *
+  * Tests construct one InMemoryState per spec and pass it to every Fake*Manager
+  * they wire up — that way fakes can interact (e.g., FakeOrganizationManager
+  * sees a user FakeUserManager just created).
+  */
+class InMemoryState {
+  val organizations: TrieMap[Int, Organization] = new TrieMap()
+  val users: TrieMap[Int, User] = new TrieMap()
+  val orgUsers: TrieMap[(Int, Int), OrganizationUser] = new TrieMap()
+  val orgUserPermissions: TrieMap[(Int, Int), DBPermission] = new TrieMap()
+  val tokens: TrieMap[String, Token] = new TrieMap()
+
+  private val ids = new AtomicInteger(1)
+  def newId(): Int = ids.getAndIncrement()
+}

--- a/authorization-service/src/main/scala/com/pennsieve/authorization/AuthorizationWebServer.scala
+++ b/authorization-service/src/main/scala/com/pennsieve/authorization/AuthorizationWebServer.scala
@@ -45,9 +45,9 @@ object AuthorizationWebServer extends App with WebServer with LazyLogging {
 
   val container: ResourceContainer =
     new InsecureContainer(config) with DatabaseContainer
-    with UserManagerContainer with OrganizationManagerContainer
+    with DefaultUserManagerContainer with DefaultOrganizationManagerContainer
     with JwtContainer with TermsOfServiceManagerContainer
-    with TokenManagerContainer
+    with DefaultTokenManagerContainer
 
   val healthCheck = new HealthCheckService(
     Map("postgres" -> HealthCheck.postgresHealthCheck(container.db))

--- a/authorization-service/src/main/scala/com/pennsieve/authorization/Router.scala
+++ b/authorization-service/src/main/scala/com/pennsieve/authorization/Router.scala
@@ -39,6 +39,7 @@ import scala.concurrent.ExecutionContext
 
 object Router {
   type ResourceContainer = Container
+    with DatabaseContainer
     with AuthorizationContainer
     with JwtContainer
     with TermsOfServiceManagerContainer

--- a/authorization-service/src/test/scala/com/pennsieve/authorization/routes/AuthorizationServiceSpec.scala
+++ b/authorization-service/src/test/scala/com/pennsieve/authorization/routes/AuthorizationServiceSpec.scala
@@ -54,9 +54,9 @@ trait AuthorizationServiceSpec
 
     val diContainer =
       new InsecureContainer(authorizationConfig) with DatabaseContainer
-      with UserManagerContainer with OrganizationManagerContainer
+      with DefaultUserManagerContainer with DefaultOrganizationManagerContainer
       with JwtContainer with TermsOfServiceManagerContainer
-      with TokenManagerContainer {
+      with DefaultTokenManagerContainer {
         override val postgresUseSSL = false
       }
 

--- a/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
@@ -166,9 +166,10 @@ trait CoreContainer extends UserManagerContainer {
 trait InsecureCoreContainer
     extends CoreContainer
     with DatabaseContainer
-    with OrganizationManagerContainer
+    with DefaultUserManagerContainer
+    with DefaultOrganizationManagerContainer
     with TermsOfServiceManagerContainer
-    with TokenManagerContainer
+    with DefaultTokenManagerContainer
     with ContextLoggingContainer {
   self: Container =>
 
@@ -177,6 +178,7 @@ trait InsecureCoreContainer
 
 trait SecureCoreContainer
     extends CoreContainer
+    with DefaultUserManagerContainer
     with DatasetManagerContainer
     with DatasetPreviewManagerContainer
     with ContributorManagerContainer
@@ -187,7 +189,7 @@ trait SecureCoreContainer
     with TimeSeriesManagerContainer
     with FilesManagerContainer
     with MetadataManagerContainer
-    with OrganizationManagerContainer
+    with DefaultOrganizationManagerContainer
     with TermsOfServiceManagerContainer
     with ExternalFilesContainer
     with ExternalPublicationContainer
@@ -201,9 +203,9 @@ trait SecureCoreContainer
     new AnnotationManager(self.organization, db)
 
   override lazy val organizationManager: SecureOrganizationManager =
-    new SecureOrganizationManager(db, user)
+    new SecureOrganizationManagerImpl(db, user)
   lazy val tokenManager: SecureTokenManager =
-    new SecureTokenManager(user, db)
+    new SecureTokenManagerImpl(user, db)
   lazy val teamManager: TeamManager = TeamManager(organizationManager)
   lazy val userInviteManager: UserInviteManager = new UserInviteManager(db)
 
@@ -453,15 +455,22 @@ trait PackageContainer {
 }
 
 trait OrganizationManagerContainer {
+  val organizationManager: OrganizationManager
+}
+
+trait DefaultOrganizationManagerContainer extends OrganizationManagerContainer {
   self: DatabaseContainer =>
-  lazy val organizationManager: OrganizationManager = new OrganizationManager(
-    db
-  )
+  lazy val organizationManager: OrganizationManager =
+    new OrganizationManagerImpl(db)
 }
 
 trait TokenManagerContainer {
+  val tokenManager: TokenManager
+}
+
+trait DefaultTokenManagerContainer extends TokenManagerContainer {
   self: DatabaseContainer =>
-  lazy val tokenManager: TokenManager = new TokenManager(db)
+  lazy val tokenManager: TokenManager = new TokenManagerImpl(db)
 }
 
 trait TermsOfServiceManagerContainer {
@@ -472,9 +481,15 @@ trait TermsOfServiceManagerContainer {
     new CustomTermsOfServiceManager(db)
 }
 
-trait UserManagerContainer extends DatabaseContainer {
+trait UserManagerContainer {
+  val userManager: UserManager
+}
+
+trait DefaultUserManagerContainer
+    extends UserManagerContainer
+    with DatabaseContainer {
   self: Container =>
-  lazy val userManager = new UserManager(db)
+  lazy val userManager: UserManager = new UserManagerImpl(db)
 }
 
 trait TimeSeriesManagerContainer

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -111,7 +111,7 @@ class DatasetManager(
   val contributor: ContributorMapper = new ContributorMapper(organization)
 
   val contributorManager: ContributorManager =
-    new ContributorManager(db, actor, contributor, new UserManager(db))
+    new ContributorManager(db, actor, contributor, new UserManagerImpl(db))
 
   val datasetStatusManager: DatasetStatusManager =
     new DatasetStatusManager(db, organization)
@@ -152,7 +152,7 @@ class DatasetManager(
     new DatasetIgnoreFilesMapper(organization)
 
   val organizationManager: OrganizationManager =
-    new OrganizationManager(db)
+    new OrganizationManagerImpl(db)
 
   val datasetRegistrationMapper: DatasetRegistrationMapper =
     new DatasetRegistrationMapper(organization)

--- a/core/src/main/scala/com/pennsieve/managers/OrganizationManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/OrganizationManager.scala
@@ -48,7 +48,7 @@ object OrganizationManager {
   )
 
   def apply(db: Database): OrganizationManager =
-    new OrganizationManager(db)
+    new OrganizationManagerImpl(db)
 
   /**
     * Result of inviting a user to an organization. Either a new user is
@@ -66,7 +66,9 @@ object OrganizationManager {
   }
 }
 
-class OrganizationManager(db: Database) {
+trait OrganizationManager {
+
+  def db: Database
 
   def get(
     id: Int
@@ -449,14 +451,17 @@ class OrganizationManager(db: Database) {
   }
 }
 
+class OrganizationManagerImpl(val db: Database) extends OrganizationManager
+
 case class UpdateOrganization(
   name: Option[String],
   subscription: Option[Subscription],
   colorTheme: Option[ColorTheme]
 )
 
-class SecureOrganizationManager(val db: Database, val actor: User)
-    extends OrganizationManager(db) {
+trait SecureOrganizationManager extends OrganizationManager {
+
+  def actor: User
 
   import OrganizationManager.AddEmailResult
 
@@ -1005,3 +1010,6 @@ class SecureOrganizationManager(val db: Database, val actor: User)
   ): EitherT[Future, CoreError, Boolean] =
     hasFeatureFlagEnabled(id, Feature.SandboxOrgFeature)
 }
+
+class SecureOrganizationManagerImpl(val db: Database, val actor: User)
+    extends SecureOrganizationManager

--- a/core/src/main/scala/com/pennsieve/managers/TokenManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/TokenManager.scala
@@ -36,7 +36,13 @@ import com.pennsieve.models.DBPermission.{ Read, Write }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class TokenManager(db: Database) {
+object TokenManager {
+  def apply(db: Database): TokenManager = new TokenManagerImpl(db)
+}
+
+trait TokenManager {
+
+  def db: Database
 
   def create(
     name: String,
@@ -143,7 +149,11 @@ class TokenManager(db: Database) {
       .whenNone[CoreError](NotFound(s"Organization ${token.organizationId}"))
 }
 
-class SecureTokenManager(actor: User, db: Database) extends TokenManager(db) {
+class TokenManagerImpl(val db: Database) extends TokenManager
+
+trait SecureTokenManager extends TokenManager {
+
+  def actor: User
 
   override def create(
     name: String,
@@ -211,3 +221,6 @@ class SecureTokenManager(actor: User, db: Database) extends TokenManager(db) {
   }
 
 }
+
+class SecureTokenManagerImpl(val actor: User, val db: Database)
+    extends SecureTokenManager

--- a/core/src/main/scala/com/pennsieve/managers/UserManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/UserManager.scala
@@ -40,7 +40,13 @@ import com.pennsieve.traits.PostgresProfile.api._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Random
 
-class UserManager(db: Database) {
+object UserManager {
+  def apply(db: Database): UserManager = new UserManagerImpl(db)
+}
+
+trait UserManager {
+
+  def db: Database
 
   private def randomColor: String = {
     val colors = List(
@@ -487,3 +493,5 @@ class UserManager(db: Database) {
   }
 
 }
+
+class UserManagerImpl(val db: Database) extends UserManager

--- a/core/src/test/scala/com/pennsieve/managers/BaseManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/BaseManagerSpec.scala
@@ -126,9 +126,9 @@ trait ManagerSpec
 
     database = postgresDB.forURL
 
-    userManager = new UserManager(database)
+    userManager = new UserManagerImpl(database)
     userInviteManager = new UserInviteManager(database)
-    tokenManager = new TokenManager(database)
+    tokenManager = new TokenManagerImpl(database)
   }
 
   override def afterAll(): Unit = {
@@ -143,7 +143,7 @@ trait ManagerSpec
     new TestableOrganizationManager(false, database, user)
 
   def secureTokenManager(user: User = superAdmin): SecureTokenManager =
-    new SecureTokenManager(user, database)
+    new SecureTokenManagerImpl(user, database)
 
   def changelogManager(
     organization: Organization = testOrganization,
@@ -199,7 +199,7 @@ trait ManagerSpec
       database,
       user,
       contributorsMapper,
-      new UserManager(database)
+      new UserManagerImpl(database)
     )
   }
 

--- a/core/src/test/scala/com/pennsieve/managers/TokenManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/TokenManagerSpec.scala
@@ -137,6 +137,48 @@ class TokenManagerSpec extends BaseManagerSpec {
     assert(tokens.contains(tokenTwo))
   }
 
+  "get(user, organization)" should "exclude tokens belonging to other users" in {
+    val user = createUser()
+    val otherUser = createUser(email = "other@test.com")
+
+    val (userToken, _) = secureTokenManager(user)
+      .create("user's token", user, testOrganization, mockCognitoClient)
+      .await
+      .value
+    val (otherToken, _) = secureTokenManager(otherUser)
+      .create(
+        "other user's token",
+        otherUser,
+        testOrganization,
+        mockCognitoClient
+      )
+      .await
+      .value
+
+    val tokens =
+      secureTokenManager(user).get(user, testOrganization).await.value
+    assert(tokens.map(_.id).contains(userToken.id))
+    assert(!tokens.map(_.id).contains(otherToken.id))
+  }
+
+  "get(user, organization)" should "exclude tokens from other organizations" in {
+    val user = createUser()
+    val _secureTokenManager = secureTokenManager(user)
+
+    val (orgOneToken, _) = _secureTokenManager
+      .create("org one token", user, testOrganization, mockCognitoClient)
+      .await
+      .value
+    val (orgTwoToken, _) = _secureTokenManager
+      .create("org two token", user, testOrganization2, mockCognitoClient)
+      .await
+      .value
+
+    val tokens = _secureTokenManager.get(user, testOrganization).await.value
+    assert(tokens.map(_.id).contains(orgOneToken.id))
+    assert(!tokens.map(_.id).contains(orgTwoToken.id))
+  }
+
   "update" should "change the name of an api token" in {
     val user = createUser()
     val _secureTokenManager = secureTokenManager(user)

--- a/core/src/test/scala/com/pennsieve/managers/UserManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/UserManagerSpec.scala
@@ -163,7 +163,7 @@ class UserManagerSpec extends BaseManagerSpec {
     assert(user.preferredOrganizationId == Some(orgsInvites.last._1.id))
 
     val secureOrganizationManager =
-      new SecureOrganizationManager(database, user)
+      new SecureOrganizationManagerImpl(database, user)
     orgsInvites.foreach {
       case (org, _) =>
         secureOrganizationManager.get(org.id).await.value

--- a/core/src/test/scala/com/pennsieve/managers/UserOrganizationManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/UserOrganizationManagerSpec.scala
@@ -50,7 +50,8 @@ class UserOrganizationManagerSpec
   }
 
   "detecting schemas" should "detect existing schemas" in {
-    val localOrgManager = new SecureOrganizationManager(database, superAdmin)
+    val localOrgManager =
+      new SecureOrganizationManagerImpl(database, superAdmin)
 
     database.run(createSchema(testOrgSchemaId.toString)).await
 
@@ -191,11 +192,11 @@ class UserOrganizationManagerSpec
     organizationThreeAdmins should not contain userOne
 
     val organizationManagerOne =
-      new SecureOrganizationManager(database, userOne)
+      new SecureOrganizationManagerImpl(database, userOne)
     val organizationManagerTwo =
-      new SecureOrganizationManager(database, userTwo)
+      new SecureOrganizationManagerImpl(database, userTwo)
     val organizationManagerThree =
-      new SecureOrganizationManager(database, userThree)
+      new SecureOrganizationManagerImpl(database, userThree)
 
     // you can't add yourself to someone else's organization
     assert(

--- a/core/src/test/scala/com/pennsieve/test/helpers/CognitoJwtSeed.scala
+++ b/core/src/test/scala/com/pennsieve/test/helpers/CognitoJwtSeed.scala
@@ -31,7 +31,7 @@ import software.amazon.awssdk.regions.Region
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait CognitoJwtSeed[
-  SeedContainer <: OrganizationManagerContainer with UserManagerContainer
+  SeedContainer <: OrganizationManagerContainer with UserManagerContainer with DatabaseContainer
 ] extends CoreSeed[SeedContainer] {
 
   var adminCognitoJwt: Option[String] = None

--- a/core/src/test/scala/com/pennsieve/test/helpers/CoreSeed.scala
+++ b/core/src/test/scala/com/pennsieve/test/helpers/CoreSeed.scala
@@ -18,6 +18,7 @@ package com.pennsieve.test.helpers
 
 import com.pennsieve.traits.PostgresProfile.api._
 import com.pennsieve.core.utilities.{
+  DatabaseContainer,
   OrganizationManagerContainer,
   PostgresDatabase,
   UserManagerContainer
@@ -30,7 +31,7 @@ import org.scalatest.EitherValues._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait CoreSeed[
-  SeedContainer <: OrganizationManagerContainer with UserManagerContainer
+  SeedContainer <: OrganizationManagerContainer with UserManagerContainer with DatabaseContainer
 ] extends TestDatabase {
 
   var userManager: UserManager = _

--- a/core/src/test/scala/com/pennsieve/test/helpers/CoreSpecHarness.scala
+++ b/core/src/test/scala/com/pennsieve/test/helpers/CoreSpecHarness.scala
@@ -27,7 +27,7 @@ import org.scalatest.{
 import com.typesafe.config.{ Config, ConfigFactory, ConfigValueFactory }
 
 trait CoreSpecHarness[
-  Container <: OrganizationManagerContainer with UserManagerContainer
+  Container <: OrganizationManagerContainer with UserManagerContainer with DatabaseContainer
 ] extends SuiteMixin
     with BeforeAndAfterEach
     with BeforeAndAfterAll

--- a/core/src/test/scala/com/pennsieve/test/helpers/TestContainer.scala
+++ b/core/src/test/scala/com/pennsieve/test/helpers/TestContainer.scala
@@ -21,7 +21,7 @@ import cats.data._
 import com.pennsieve.core.utilities.SecureCoreContainer
 import com.pennsieve.core.utilities.{ SecureContainer, SecureCoreContainer }
 import com.pennsieve.domain.{ CoreError, NotFound }
-import com.pennsieve.managers.SecureOrganizationManager
+import com.pennsieve.managers.SecureOrganizationManagerImpl
 import com.pennsieve.models.{ Organization, User }
 import com.pennsieve.traits.PostgresProfile.api._
 
@@ -31,7 +31,7 @@ class TestableOrganizationManager(
   checkSchema: Boolean,
   db: Database,
   user: User
-) extends SecureOrganizationManager(db, user) {
+) extends SecureOrganizationManagerImpl(db, user) {
 
   override def schemaExists(
     organization: Organization

--- a/invite-cognito-user/src/main/scala/com/pennsieve/Main.scala
+++ b/invite-cognito-user/src/main/scala/com/pennsieve/Main.scala
@@ -58,7 +58,7 @@ import AwaitableImplicits._
 class InviteContainer(val config: Config)
     extends Container
     with DatabaseContainer
-    with UserManagerContainer {}
+    with DefaultUserManagerContainer {}
 
 object Main extends App {
 


### PR DESCRIPTION
## Changes Proposed
Starting to mock managers in the API tests in order to keep integration tests strictly relegated to `core` and unit test `api` and other downstream projects.

Using containers for every test is overkill and leads to this repository having ~1hr long test times.

This PR takes a first pass at converting one API controller test spec over to unit from integration.

```
time sbt "api/testOnly com.pennsieve.api.APITokenControllerSpecs"
```
  - On main: ~30s ScalaTest + Docker container startup (full Postgres testcontainer flow).
  - On this branch: 1.7s ScalaTest, ~7s wall clock, no Docker.

## Checklist
- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
