### PR TITLE
abstract remaining managers into traits

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/OrganizationsController.scala
+++ b/api/src/main/scala/com/pennsieve/api/OrganizationsController.scala
@@ -35,6 +35,7 @@ import com.pennsieve.helpers.either.EitherTErrorHandler.implicits._
 import com.pennsieve.helpers.ResultHandlers._
 import com.pennsieve.managers.{
   DatasetStatusManager,
+  DatasetStatusManagerImpl,
   OrganizationManager,
   SecureOrganizationManager,
   StorageManager,
@@ -1450,7 +1451,10 @@ class OrganizationsController(
           .getByNodeId(organizationId, DBPermission.Guest)
           .coreErrorToActionResult()
 
-        status <- new DatasetStatusManager(insecureContainer.db, organization).getAllWithUsage
+        status <- new DatasetStatusManagerImpl(
+          insecureContainer.db,
+          organization
+        ).getAllWithUsage
           .coreErrorToActionResult()
 
       } yield status.map(DatasetStatusDTO(_))
@@ -1481,8 +1485,10 @@ class OrganizationsController(
           .getByNodeId(organizationId, DBPermission.Administer)
           .coreErrorToActionResult()
 
-        status <- new DatasetStatusManager(insecureContainer.db, organization)
-          .create(displayName = body.displayName, color = body.color)
+        status <- new DatasetStatusManagerImpl(
+          insecureContainer.db,
+          organization
+        ).create(displayName = body.displayName, color = body.color)
           .coreErrorToActionResult()
 
       } yield DatasetStatusDTO(status, inUse = DatasetStatusInUse(false))
@@ -1516,8 +1522,10 @@ class OrganizationsController(
           .getByNodeId(organizationId, DBPermission.Administer)
           .coreErrorToActionResult()
 
-        status <- new DatasetStatusManager(insecureContainer.db, organization)
-          .update(
+        status <- new DatasetStatusManagerImpl(
+          insecureContainer.db,
+          organization
+        ).update(
             id = datasetStatusId,
             displayName = body.displayName,
             color = body.color
@@ -1553,8 +1561,10 @@ class OrganizationsController(
           .getByNodeId(organizationId, DBPermission.Administer)
           .coreErrorToActionResult()
 
-        status <- new DatasetStatusManager(insecureContainer.db, organization)
-          .delete(id = datasetStatusId)
+        status <- new DatasetStatusManagerImpl(
+          insecureContainer.db,
+          organization
+        ).delete(id = datasetStatusId)
           .coreErrorToActionResult()
 
       } yield DatasetStatusDTO(status)

--- a/api/src/test/scala/com/pennsieve/api/BaseApiUnitTest.scala
+++ b/api/src/test/scala/com/pennsieve/api/BaseApiUnitTest.scala
@@ -46,14 +46,25 @@ import com.pennsieve.helpers.APIContainers.{
   SecureContainerBuilderType
 }
 import com.pennsieve.helpers.fakes.{
+  FakeChangelogManager,
   FakeCollectionManager,
   FakeContributorManager,
   FakeCustomTermsOfServiceManager,
+  FakeDataUseAgreementManager,
+  FakeDatasetAssetsManager,
+  FakeDatasetManager,
+  FakeDatasetPreviewManager,
+  FakeDatasetPublicationStatusManager,
+  FakeDatasetStatusManager,
+  FakeExternalPublicationManager,
+  FakeFileManager,
+  FakePackageManager,
   FakePennsieveTermsOfServiceManager,
   FakeSecureOrganizationManager,
   FakeSecureTokenManager,
   FakeStorageManager,
   FakeUserManager,
+  FakeWebhookManager,
   InMemoryState
 }
 import com.pennsieve.helpers.{
@@ -63,15 +74,26 @@ import com.pennsieve.helpers.{
 }
 import com.pennsieve.test.helpers.AwaitableImplicits
 import com.pennsieve.managers.{
+  ChangelogManager,
   CollectionManager,
   ContributorManager,
   CustomTermsOfServiceManager,
+  DataUseAgreementManager,
+  DatasetAssetsManager,
+  DatasetManager,
+  DatasetPreviewManager,
+  DatasetPublicationStatusManager,
+  DatasetStatusManager,
+  ExternalPublicationManager,
+  FileManager,
+  PackageManager,
   PennsieveTermsOfServiceManager,
   SecureOrganizationManager,
   SecureTokenManager,
   StorageServiceClientTrait,
   UserInviteManager,
-  UserManager
+  UserManager,
+  WebhookManager
 }
 import com.pennsieve.models.{ CognitoId, Organization, Role, User }
 import com.pennsieve.traits.PostgresProfile.api._
@@ -260,6 +282,30 @@ trait BaseApiUnitTest
         override lazy val customTermsOfServiceManager
           : CustomTermsOfServiceManager =
           new FakeCustomTermsOfServiceManager(st)
+        override lazy val datasetManager: DatasetManager =
+          new FakeDatasetManager(st, org, u)
+        override lazy val packageManager: PackageManager =
+          new FakePackageManager(datasetManager)
+        override lazy val fileManager: FileManager =
+          new FakeFileManager(packageManager, org)
+        override lazy val datasetStatusManager: DatasetStatusManager =
+          new FakeDatasetStatusManager(st, org)
+        override lazy val datasetPreviewManager: DatasetPreviewManager =
+          new FakeDatasetPreviewManager(st, org)
+        override lazy val datasetPublicationStatusManager
+          : DatasetPublicationStatusManager =
+          new FakeDatasetPublicationStatusManager(st, org, u)
+        override lazy val dataUseAgreementManager: DataUseAgreementManager =
+          new FakeDataUseAgreementManager(st, org)
+        override lazy val datasetAssetsManager: DatasetAssetsManager =
+          new FakeDatasetAssetsManager(st, org)
+        override lazy val externalPublicationManager
+          : ExternalPublicationManager =
+          new FakeExternalPublicationManager(st, org)
+        override lazy val webhookManager: WebhookManager =
+          new FakeWebhookManager(st, org, u)
+        override lazy val changelogManager: ChangelogManager =
+          new FakeChangelogManager(st, org, u)
       }
   }
 

--- a/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestOrganizationsController.scala
@@ -24,6 +24,7 @@ import com.pennsieve.db.UserInvitesMapper
 import com.pennsieve.dtos.{ DatasetStatusDTO, TeamDTO, UserDTO, UserInviteDTO }
 import com.pennsieve.managers.{
   DatasetStatusManager,
+  DatasetStatusManagerImpl,
   SecureOrganizationManagerImpl,
   UpdateOrganization
 }
@@ -1232,7 +1233,7 @@ class TestOrganizationsController extends BaseApiTest with DataSetTestMixin {
 
     val datasetStatusManager = secureContainer.datasetStatusManager
     val externalDatasetStatusManager =
-      new DatasetStatusManager(secureContainer.db, externalOrganization)
+      new DatasetStatusManagerImpl(secureContainer.db, externalOrganization)
 
     // Can create status in `loggedInOrganization`
     postJson(

--- a/api/src/test/scala/com/pennsieve/api/TestPackagesController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestPackagesController.scala
@@ -39,7 +39,12 @@ import com.pennsieve.helpers.{
   MockUrlShortenerClient,
   PackagesTestMixin
 }
-import com.pennsieve.managers.{ FileManager, PackageManager }
+import com.pennsieve.managers.{
+  FileManager,
+  FileManagerImpl,
+  PackageManager,
+  PackageManagerImpl
+}
 import com.pennsieve.models.PackageState.{
   namesToValuesMap,
   PROCESSING,
@@ -933,7 +938,7 @@ class TestPackagesController
       .await
       .value
 
-    val filesManager = new FileManager(packageManager, loggedInOrganization)
+    val filesManager = new FileManagerImpl(packageManager, loggedInOrganization)
     val testFile = (1 to 2).toList.map { idx =>
       filesManager
         .create(
@@ -980,7 +985,7 @@ class TestPackagesController
       .await
       .value
 
-    val filesManager = new FileManager(packageManager, loggedInOrganization)
+    val filesManager = new FileManagerImpl(packageManager, loggedInOrganization)
     val testFile = filesManager
       .create(
         name = oldName,
@@ -1113,7 +1118,7 @@ class TestPackagesController
 
     val fileSize = 10
     val numberOfFiles = 5
-    val filesManager = new FileManager(packageManager, loggedInOrganization)
+    val filesManager = new FileManagerImpl(packageManager, loggedInOrganization)
     val bftsFiles = (1 to numberOfFiles).toList.map { idx =>
       filesManager
         .create(

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeChangelogManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeChangelogManager.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.aws.sns.{ MockSNS, SNSClient }
+import com.pennsieve.core.utilities.ContainerTypes.SnsTopic
+import com.pennsieve.managers.ChangelogManager
+import com.pennsieve.models.{ Organization, User }
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. Uses MockSNS for the SNS client by default — tests can
+  * override or supply their own. */
+class FakeChangelogManager(
+  val state: InMemoryState,
+  override val organization: Organization,
+  val actor: User,
+  val snsTopic: SnsTopic = "test-topic",
+  val sns: SNSClient = new MockSNS
+) extends ChangelogManager {
+
+  def db: Database =
+    sys.error(
+      "FakeChangelogManager: a method not yet stubbed by your test tried to " +
+        "use the database. Override the method on this fake."
+    )
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDataUseAgreementManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDataUseAgreementManager.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.managers.DataUseAgreementManager
+import com.pennsieve.models.Organization
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. */
+class FakeDataUseAgreementManager(
+  val state: InMemoryState,
+  override val organization: Organization
+) extends DataUseAgreementManager {
+
+  def db: Database =
+    sys.error(
+      "FakeDataUseAgreementManager: a method not yet stubbed by your test " +
+        "tried to use the database. Override the method on this fake."
+    )
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetAssetsManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetAssetsManager.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.db.DatasetsMapper
+import com.pennsieve.managers.DatasetAssetsManager
+import com.pennsieve.models.Organization
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. */
+class FakeDatasetAssetsManager(val state: InMemoryState, org: Organization)
+    extends DatasetAssetsManager {
+
+  def db: Database =
+    sys.error(
+      "FakeDatasetAssetsManager: a method not yet stubbed by your test " +
+        "tried to use the database. Override the method on this fake."
+    )
+
+  override lazy val datasetsMapper: DatasetsMapper =
+    new DatasetsMapper(org)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetManager.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.db.DatasetsMapper
+import com.pennsieve.managers.DatasetManager
+import com.pennsieve.models.{ Organization, User }
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/**
+  * Skeleton fake for `DatasetManager`. Provides abstract trait members
+  * (db throws, datasetsMapper lazily constructs from organization) so the
+  * cake DI in `BaseApiUnitTest` can resolve. Specific tests should subclass
+  * or amend this fake to override the methods they exercise; any unstubbed
+  * method will fall through to the trait body, hit `db`, and fail loudly.
+  */
+class FakeDatasetManager(
+  val state: InMemoryState,
+  org: Organization,
+  val actor: User
+) extends DatasetManager {
+
+  def db: Database =
+    sys.error(
+      "FakeDatasetManager: a method not yet stubbed by your test tried to " +
+        "use the database. Override the method on this fake."
+    )
+
+  // The Slick TableQuery itself doesn't touch `db` at construction; only on
+  // `db.run(...)`. So we can supply a real one without breaking the
+  // throwing-`db` invariant. The trait derives `organization` from this.
+  override lazy val datasetsMapper: DatasetsMapper =
+    new DatasetsMapper(org)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetPreviewManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetPreviewManager.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.db.DatasetsMapper
+import com.pennsieve.managers.DatasetPreviewManager
+import com.pennsieve.models.Organization
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. */
+class FakeDatasetPreviewManager(val state: InMemoryState, org: Organization)
+    extends DatasetPreviewManager {
+
+  def db: Database =
+    sys.error(
+      "FakeDatasetPreviewManager: a method not yet stubbed by your test " +
+        "tried to use the database. Override the method on this fake."
+    )
+
+  override lazy val datasetsMapper: DatasetsMapper =
+    new DatasetsMapper(org)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetPublicationStatusManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetPublicationStatusManager.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.db.{ ChangelogEventMapper, DatasetPublicationStatusMapper }
+import com.pennsieve.managers.DatasetPublicationStatusManager
+import com.pennsieve.models.{ Organization, User }
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. */
+class FakeDatasetPublicationStatusManager(
+  val state: InMemoryState,
+  organization: Organization,
+  val actor: User
+) extends DatasetPublicationStatusManager {
+
+  def db: Database =
+    sys.error(
+      "FakeDatasetPublicationStatusManager: a method not yet stubbed by " +
+        "your test tried to use the database. Override the method on this fake."
+    )
+
+  // Slick mappers; only touch db on `.run(...)`.
+  override lazy val datasetPublicationStatusMapper
+    : DatasetPublicationStatusMapper =
+    new DatasetPublicationStatusMapper(organization)
+  override lazy val changelogEventMapper: ChangelogEventMapper =
+    new ChangelogEventMapper(organization)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetStatusManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeDatasetStatusManager.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.managers.DatasetStatusManager
+import com.pennsieve.models.Organization
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. */
+class FakeDatasetStatusManager(
+  val state: InMemoryState,
+  override val organization: Organization
+) extends DatasetStatusManager {
+
+  def db: Database =
+    sys.error(
+      "FakeDatasetStatusManager: a method not yet stubbed by your test tried " +
+        "to use the database. Override the method on this fake."
+    )
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeExternalPublicationManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeExternalPublicationManager.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.managers.ExternalPublicationManager
+import com.pennsieve.models.Organization
+import com.pennsieve.traits.PostgresProfile.api.Database
+
+/** Skeleton fake. */
+class FakeExternalPublicationManager(
+  val state: InMemoryState,
+  override val organization: Organization
+) extends ExternalPublicationManager {
+
+  def db: Database =
+    sys.error(
+      "FakeExternalPublicationManager: a method not yet stubbed by your test " +
+        "tried to use the database. Override the method on this fake."
+    )
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeFileManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeFileManager.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.managers.{ FileManager, PackageManager }
+import com.pennsieve.models.Organization
+
+/** Skeleton fake. */
+class FakeFileManager(
+  val packageManager: PackageManager,
+  override val organization: Organization
+) extends FileManager

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakePackageManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakePackageManager.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.managers.{ DatasetManager, PackageManager }
+
+/** Skeleton fake. Inherits db/actor/datasetsMapper from the supplied (fake)
+  * DatasetManager. Methods fall through to the trait body and hit the
+  * throwing `db` until tests override them. */
+class FakePackageManager(val datasetManager: DatasetManager)
+    extends PackageManager

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/FakeWebhookManager.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/FakeWebhookManager.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 University of Pennsylvania
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pennsieve.helpers.fakes
+
+import com.pennsieve.db.{
+  WebhookEventSubscriptionsMapper,
+  WebhookEventTypesMapper,
+  WebhooksMapper
+}
+import com.pennsieve.managers.WebhookManager
+import com.pennsieve.models.{ Organization, User }
+import com.pennsieve.traits.PostgresProfile
+
+/** Skeleton fake. */
+class FakeWebhookManager(
+  val state: InMemoryState,
+  org: Organization,
+  val actor: User
+) extends WebhookManager {
+
+  def db: PostgresProfile.api.Database =
+    sys.error(
+      "FakeWebhookManager: a method not yet stubbed by your test tried to " +
+        "use the database. Override the method on this fake."
+    )
+
+  // Slick mappers, no db access at construction.
+  override lazy val webhooksMapper: WebhooksMapper =
+    new WebhooksMapper(org)
+  override lazy val webhookEventSubscriptionsMapper
+    : WebhookEventSubscriptionsMapper =
+    new WebhookEventSubscriptionsMapper(org)
+  override lazy val webhookEventTypesMapper: WebhookEventTypesMapper =
+    new WebhookEventTypesMapper(org)
+}

--- a/api/src/test/scala/com/pennsieve/helpers/fakes/InMemoryState.scala
+++ b/api/src/test/scala/com/pennsieve/helpers/fakes/InMemoryState.scala
@@ -18,14 +18,26 @@ package com.pennsieve.helpers.fakes
 
 import com.pennsieve.db.{ CustomTermsOfService, PennsieveTermsOfService }
 import com.pennsieve.models.{
+  ChangelogEventAndType,
   Collection,
   Contributor,
   DBPermission,
+  DataUseAgreement,
+  Dataset,
+  DatasetAsset,
+  DatasetPreviewer,
+  DatasetPublicationStatus,
+  DatasetStatus,
+  ExternalPublication,
   Feature,
+  File,
   Organization,
   OrganizationUser,
+  Package,
   Token,
-  User
+  User,
+  Webhook,
+  WebhookEventSubcription
 }
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -60,6 +72,24 @@ class InMemoryState {
 
   // Custom ToS acceptance per (userId, organizationId).
   val customTos: TrieMap[(Int, Int), CustomTermsOfService] = new TrieMap()
+
+  // ---- Dataset surface (used by TestDataSetsController) ----
+  // Everything below is scoped to an organization unless noted.
+  val datasets: TrieMap[(Int, Int), Dataset] = new TrieMap()
+  val packages: TrieMap[(Int, Int), Package] = new TrieMap()
+  val files: TrieMap[(Int, Int), File] = new TrieMap()
+  val datasetStatuses: TrieMap[(Int, Int), DatasetStatus] = new TrieMap()
+  val datasetPublicationStatuses
+    : TrieMap[(Int, Int), DatasetPublicationStatus] = new TrieMap()
+  val datasetPreviewers: TrieMap[(Int, Int, Int), DatasetPreviewer] =
+    new TrieMap() // (orgId, datasetId, userId)
+  val dataUseAgreements: TrieMap[(Int, Int), DataUseAgreement] = new TrieMap()
+  val datasetAssets: TrieMap[(Int, Int), DatasetAsset] = new TrieMap()
+  val externalPublications: TrieMap[(Int, Int, String), ExternalPublication] =
+    new TrieMap() // (orgId, datasetId, doi+rel)
+  val webhooks: TrieMap[(Int, Int), Webhook] = new TrieMap()
+  val changelogEvents: TrieMap[(Int, Int), ChangelogEventAndType] =
+    new TrieMap()
 
   private val ids = new AtomicInteger(1)
   def newId(): Int = ids.getAndIncrement()

--- a/authorization-service/src/test/scala/com/pennsieve/authorization/routes/AuthorizationRoutesSpec.scala
+++ b/authorization-service/src/test/scala/com/pennsieve/authorization/routes/AuthorizationRoutesSpec.scala
@@ -55,8 +55,10 @@ import com.pennsieve.dtos.UserDTO
 import com.pennsieve.managers.{
   ContributorManager,
   DatasetManager,
+  DatasetManagerImpl,
   DatasetPreviewManager,
   DatasetPublicationStatusManager,
+  DatasetPublicationStatusManagerImpl,
   TeamManager,
   UserManager
 }
@@ -118,7 +120,7 @@ class AuthorizationRoutesSpec
 
     "return a JWT for an authorized user with a dataset claim" in {
       val datasetsMapper = new DatasetsMapper(organizationTwo)
-      val datasetManager = new DatasetManager(db, nonAdmin, datasetsMapper)
+      val datasetManager = new DatasetManagerImpl(db, nonAdmin, datasetsMapper)
       val dataset = datasetManager.create("Test Dataset").await.value
 
       testRequest(
@@ -139,7 +141,7 @@ class AuthorizationRoutesSpec
 
     "return a JWT for resolving a valid dataset by node ID" in {
       val datasetsMapper = new DatasetsMapper(organizationTwo)
-      val datasetManager = new DatasetManager(db, nonAdmin, datasetsMapper)
+      val datasetManager = new DatasetManagerImpl(db, nonAdmin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset (from node ID)")
         .await
@@ -172,13 +174,14 @@ class AuthorizationRoutesSpec
 
     "return a JWT with locked = true for datasets with the right publication status" in {
       val datasetsMapper = new DatasetsMapper(organizationTwo)
-      val datasetManager = new DatasetManager(db, nonAdmin, datasetsMapper)
-      val datasetPublicationStatusManager = new DatasetPublicationStatusManager(
-        db,
-        nonAdmin,
-        new DatasetPublicationStatusMapper(organizationTwo),
-        new ChangelogEventMapper(organizationTwo)
-      )
+      val datasetManager = new DatasetManagerImpl(db, nonAdmin, datasetsMapper)
+      val datasetPublicationStatusManager =
+        new DatasetPublicationStatusManagerImpl(
+          db,
+          nonAdmin,
+          new DatasetPublicationStatusMapper(organizationTwo),
+          new ChangelogEventMapper(organizationTwo)
+        )
 
       val dataset = datasetManager
         .create("Test Dataset (from node ID)")
@@ -404,14 +407,15 @@ class AuthorizationRoutesSpec
     "return a JWT with locked = false if the dataset is being published and the user is a publisher" in {
       val datasetsMapper = new DatasetsMapper(organizationTwo)
       val datasetManager =
-        new DatasetManager(db, nonAdmin, datasetsMapper)
+        new DatasetManagerImpl(db, nonAdmin, datasetsMapper)
 
-      val datasetPublicationStatusManager = new DatasetPublicationStatusManager(
-        db,
-        nonAdmin,
-        new DatasetPublicationStatusMapper(organizationTwo),
-        new ChangelogEventMapper(organizationTwo)
-      )
+      val datasetPublicationStatusManager =
+        new DatasetPublicationStatusManagerImpl(
+          db,
+          nonAdmin,
+          new DatasetPublicationStatusMapper(organizationTwo),
+          new ChangelogEventMapper(organizationTwo)
+        )
 
       val teamManager = TeamManager(organizationManager)
 
@@ -525,14 +529,15 @@ class AuthorizationRoutesSpec
     "return a JWT with locked = false and role = Editor if the dataset is in review (requested) and the user is a publisher" in {
       val datasetsMapper = new DatasetsMapper(organizationTwo)
       val datasetManager =
-        new DatasetManager(db, admin, datasetsMapper) // not dataset owner
+        new DatasetManagerImpl(db, admin, datasetsMapper) // not dataset owner
 
-      val datasetPublicationStatusManager = new DatasetPublicationStatusManager(
-        db,
-        nonAdmin,
-        new DatasetPublicationStatusMapper(organizationTwo),
-        new ChangelogEventMapper(organizationTwo)
-      )
+      val datasetPublicationStatusManager =
+        new DatasetPublicationStatusManagerImpl(
+          db,
+          nonAdmin,
+          new DatasetPublicationStatusMapper(organizationTwo),
+          new ChangelogEventMapper(organizationTwo)
+        )
 
       val teamManager = TeamManager(organizationManager)
 
@@ -620,7 +625,7 @@ class AuthorizationRoutesSpec
     "return a JWT for an authorized user with a dataset claim if the dataset is shared with the organization" in {
       val datasetsMapper = new DatasetsMapper(organizationTwo)
       val datasetManager =
-        new DatasetManager(db, admin, datasetsMapper)
+        new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
@@ -649,7 +654,7 @@ class AuthorizationRoutesSpec
     "return a 404 Not Found for a user requesting a dataset shared in another organization" in {
       val datasetsMapper = new DatasetsMapper(organizationOne)
       val datasetManager =
-        new DatasetManager(db, admin, datasetsMapper)
+        new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await

--- a/authorization-service/src/test/scala/com/pennsieve/authorization/routes/DiscoverAuthorizationRoutesSpec.scala
+++ b/authorization-service/src/test/scala/com/pennsieve/authorization/routes/DiscoverAuthorizationRoutesSpec.scala
@@ -32,7 +32,9 @@ import org.scalatest.EitherValues._
 import com.pennsieve.db.DatasetsMapper
 import com.pennsieve.managers.{
   DatasetManager,
+  DatasetManagerImpl,
   DatasetPreviewManager,
+  DatasetPreviewManagerImpl,
   UserManager
 }
 import com.pennsieve.models.{
@@ -77,7 +79,7 @@ class DiscoverAuthorizationRoutesSpec
 
       val datasetsMapper = new DatasetsMapper(organizationTwo)
       val datasetManager =
-        new DatasetManager(db, nonAdmin, datasetsMapper)
+        new DatasetManagerImpl(db, nonAdmin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
@@ -97,7 +99,7 @@ class DiscoverAuthorizationRoutesSpec
 
       val datasetsMapper = new DatasetsMapper(organizationTwo)
       val datasetManager =
-        new DatasetManager(db, admin, datasetsMapper)
+        new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
@@ -117,7 +119,7 @@ class DiscoverAuthorizationRoutesSpec
 
       val datasetsMapper = new DatasetsMapper(organizationTwo)
       val datasetManager =
-        new DatasetManager(db, admin, datasetsMapper)
+        new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
@@ -141,14 +143,14 @@ class DiscoverAuthorizationRoutesSpec
     "return 200 if user is a dataset previewer" in {
 
       val datasetsMapper = new DatasetsMapper(organizationTwo)
-      val datasetManager = new DatasetManager(db, admin, datasetsMapper)
+      val datasetManager = new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
         .value
 
       val datasetPreviewManager =
-        new DatasetPreviewManager(db, datasetsMapper)
+        new DatasetPreviewManagerImpl(db, datasetsMapper)
       datasetPreviewManager.grantAccess(dataset, nonAdmin).await.value
 
       organizationManager.removeUser(organizationOne, nonAdmin).await.value
@@ -165,14 +167,14 @@ class DiscoverAuthorizationRoutesSpec
 
     "return 200 if user is authorized to preview, even if he is logged on the DM platform in another organization" in {
       val datasetsMapper = new DatasetsMapper(organizationOne)
-      val datasetManager = new DatasetManager(db, admin, datasetsMapper)
+      val datasetManager = new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
         .value
 
       val datasetPreviewManager =
-        new DatasetPreviewManager(db, datasetsMapper)
+        new DatasetPreviewManagerImpl(db, datasetsMapper)
 
       val preview =
         datasetPreviewManager.grantAccess(dataset, nonAdmin).await.value
@@ -191,14 +193,14 @@ class DiscoverAuthorizationRoutesSpec
     "return 403 Forbidden if preview access is requested but not accepted" in {
 
       val datasetsMapper = new DatasetsMapper(organizationTwo)
-      val datasetManager = new DatasetManager(db, admin, datasetsMapper)
+      val datasetManager = new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
         .value
 
       val datasetPreviewManager =
-        new DatasetPreviewManager(db, datasetsMapper)
+        new DatasetPreviewManagerImpl(db, datasetsMapper)
 
       db.run(
           datasetPreviewManager.previewer.insertOrUpdate(
@@ -225,14 +227,14 @@ class DiscoverAuthorizationRoutesSpec
     "return 403 if preview access is rejected" in {
 
       val datasetsMapper = new DatasetsMapper(organizationTwo)
-      val datasetManager = new DatasetManager(db, admin, datasetsMapper)
+      val datasetManager = new DatasetManagerImpl(db, admin, datasetsMapper)
       val dataset = datasetManager
         .create("Test Dataset")
         .await
         .value
 
       val datasetPreviewManager =
-        new DatasetPreviewManager(db, datasetsMapper)
+        new DatasetPreviewManagerImpl(db, datasetsMapper)
 
       db.run(
           datasetPreviewManager.previewer.insertOrUpdate(

--- a/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
@@ -189,7 +189,7 @@ trait InsecureCoreContainer
 trait SecureCoreContainer
     extends CoreContainer
     with DefaultUserManagerContainer
-    with DatasetManagerContainer
+    with DefaultDatasetManagerContainer
     with DatasetPreviewManagerContainer
     with DefaultContributorManagerContainer
     with DefaultCollectionManagerContainer
@@ -220,10 +220,10 @@ trait SecureCoreContainer
   lazy val teamManager: TeamManager = TeamManager(organizationManager)
 
   lazy val datasetStatusManager: DatasetStatusManager =
-    new DatasetStatusManager(db, self.organization)
+    new DatasetStatusManagerImpl(db, self.organization)
 
   lazy val dataUseAgreementManager: DataUseAgreementManager =
-    new DataUseAgreementManager(db, self.organization)
+    new DataUseAgreementManagerImpl(db, self.organization)
 
   lazy val datasetPublicationStatusMapper: DatasetPublicationStatusMapper =
     new DatasetPublicationStatusMapper(self.organization)
@@ -307,7 +307,7 @@ trait DatasetPublicationStatusContainer {
   self: Container with SecureCoreContainer with ChangelogContainer =>
 
   lazy val datasetPublicationStatusManager: DatasetPublicationStatusManager =
-    new DatasetPublicationStatusManager(
+    new DatasetPublicationStatusManagerImpl(
       db,
       user,
       datasetPublicationStatusMapper,
@@ -322,7 +322,7 @@ trait ChangelogContainer {
     config.as[String]("pennsieve.changelog.sns_topic")
 
   lazy val changelogManager =
-    new ChangelogManager(db, organization, user, events_topic, sns)
+    new ChangelogManagerImpl(db, organization, user, events_topic, sns)
 
 }
 
@@ -340,14 +340,19 @@ trait DatasetContainer {
   val dataset: Dataset
 }
 
-trait DatasetManagerContainer
-    extends DatasetMapperContainer
+trait DatasetManagerContainer {
+  val datasetManager: DatasetManager
+}
+
+trait DefaultDatasetManagerContainer
+    extends DatasetManagerContainer
+    with DatasetMapperContainer
     with DatabaseContainer
     with RequestContextContainer {
   self: Container =>
 
   lazy val datasetManager: DatasetManager =
-    new DatasetManager(db, user, datasetsMapper)
+    new DatasetManagerImpl(db, user, datasetsMapper)
 }
 
 trait DataCanvasContainer {
@@ -385,7 +390,7 @@ trait DatasetPreviewManagerContainer
   self: Container =>
 
   lazy val datasetPreviewManager: DatasetPreviewManager =
-    new DatasetPreviewManager(db, datasetsMapper)
+    new DatasetPreviewManagerImpl(db, datasetsMapper)
 }
 
 trait DatasetMapperContainer {
@@ -454,7 +459,7 @@ trait DefaultCollectionManagerContainer
 trait DatasetAssetsContainer {
   self: DatasetMapperContainer with DatabaseContainer =>
   lazy val datasetAssetsManager: DatasetAssetsManager =
-    new DatasetAssetsManager(db, datasetsMapper)
+    new DatasetAssetsManagerImpl(db, datasetsMapper)
 }
 
 trait ExternalFilesMapperContainer {
@@ -476,7 +481,7 @@ trait PackageContainer {
     with DatasetManagerContainer =>
 
   lazy val packageManager: PackageManager =
-    new PackageManager(datasetManager)
+    new PackageManagerImpl(datasetManager)
 }
 
 trait OrganizationManagerContainer {
@@ -547,10 +552,11 @@ trait FilesManagerContainer
     with PackagesMapperContainer
     with DatabaseContainer
     with DataDBContainer
-    with StorageContainer {
+    with StorageContainer
+    with OrganizationContainer {
   self: Container =>
   lazy val fileManager: FileManager =
-    new FileManager(packageManager, organization)
+    new FileManagerImpl(packageManager, organization)
 }
 
 trait ExternalFilesContainer extends ExternalFilesMapperContainer {
@@ -567,7 +573,7 @@ trait ExternalPublicationContainer
   self: Container =>
 
   lazy val externalPublicationManager =
-    new ExternalPublicationManager(db, organization)
+    new ExternalPublicationManagerImpl(db, organization)
 }
 
 trait UserPermissionContainer {
@@ -602,7 +608,7 @@ trait WebhookManagerContainer
     new DatasetIntegrationsMapper(self.organization)
 
   lazy val webhookManager: WebhookManager =
-    new WebhookManager(
+    new WebhookManagerImpl(
       db,
       user,
       webhooksMapper,

--- a/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
+++ b/core/src/main/scala/com/pennsieve/core/utilities/Container.scala
@@ -321,7 +321,7 @@ trait ChangelogContainer {
   val events_topic: SnsTopic =
     config.as[String]("pennsieve.changelog.sns_topic")
 
-  lazy val changelogManager =
+  lazy val changelogManager: ChangelogManager =
     new ChangelogManagerImpl(db, organization, user, events_topic, sns)
 
 }
@@ -572,7 +572,7 @@ trait ExternalPublicationContainer
     with DatabaseContainer {
   self: Container =>
 
-  lazy val externalPublicationManager =
+  lazy val externalPublicationManager: ExternalPublicationManager =
     new ExternalPublicationManagerImpl(db, organization)
 }
 

--- a/core/src/main/scala/com/pennsieve/dtos/Builders.scala
+++ b/core/src/main/scala/com/pennsieve/dtos/Builders.scala
@@ -110,7 +110,7 @@ object Builders {
     * explosions when adding related data to the DTOs.
     */
   def datasetDTOs[
-    DIContainer <: DatasetManagerContainer with PackageDTODIContainer with OrganizationManagerContainer with DatasetAssetsContainer
+    DIContainer <: DatasetManagerContainer with PackageDTODIContainer with OrganizationManagerContainer with DatasetAssetsContainer with RequestContextContainer with DatabaseContainer
   ](
     datasetAndStatus: Seq[DatasetAndStatus],
     includeBannerUrl: Boolean = false,
@@ -242,7 +242,7 @@ object Builders {
   }
 
   def datasetDTO[
-    DIContainer <: DatasetManagerContainer with PackageDTODIContainer with OrganizationManagerContainer with DatasetAssetsContainer
+    DIContainer <: DatasetManagerContainer with PackageDTODIContainer with OrganizationManagerContainer with DatasetAssetsContainer with RequestContextContainer with DatabaseContainer
   ](
     dataset: Dataset,
     status: DatasetStatus,

--- a/core/src/main/scala/com/pennsieve/managers/ChangelogManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/ChangelogManager.scala
@@ -58,13 +58,12 @@ import java.time.{ LocalDate, ZonedDateTime }
   *
   * https://blackfynn.atlassian.net/wiki/spaces/PM/pages/1861976109/Dataset+Changelog
   */
-class ChangelogManager(
-  val db: Database,
-  val organization: Organization,
-  val actor: User,
-  val snsTopic: SnsTopic,
-  val sns: SNSClient
-) extends LazyLogging {
+trait ChangelogManager extends LazyLogging {
+  def db: Database
+  def organization: Organization
+  def actor: User
+  def snsTopic: SnsTopic
+  def sns: SNSClient
 
   lazy val changelogEventMapper = new ChangelogEventMapper(organization)
 
@@ -493,7 +492,7 @@ class ChangelogManager(
       .toEitherT
   }
 
-  implicit val getEventGroupResult
+  implicit lazy val getEventGroupResult
     : GetResult[(ChangelogEventGroup, ChangelogEventAndType)] = {
     GetResult { p =>
       val datasetId = p.<<[Int]
@@ -540,20 +539,28 @@ class ChangelogManager(
     }
   }
 
-  implicit val setChangelogEventNameParameter
+  implicit lazy val setChangelogEventNameParameter
     : SetParameter[ChangelogEventName] =
     new SetParameter[ChangelogEventName] {
       def apply(e: ChangelogEventName, pp: PositionedParameters) =
         pp.setString(e.entryName)
     }
 
-  implicit val getChangelogEventNameResult: GetResult[ChangelogEventName] =
+  implicit lazy val getChangelogEventNameResult: GetResult[ChangelogEventName] =
     GetResult { p =>
       ChangelogEventName.withName(p.<<[String])
     }
 
-  implicit val getEventGroupPeriodResult: GetResult[EventGroupPeriod] =
+  implicit lazy val getEventGroupPeriodResult: GetResult[EventGroupPeriod] =
     GetResult { p =>
       EventGroupPeriod.withName(p.<<[String])
     }
 }
+
+class ChangelogManagerImpl(
+  val db: Database,
+  val organization: Organization,
+  val actor: User,
+  val snsTopic: SnsTopic,
+  val sns: SNSClient
+) extends ChangelogManager

--- a/core/src/main/scala/com/pennsieve/managers/DataCanvasManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DataCanvasManager.scala
@@ -97,7 +97,7 @@ class DataCanvasManager(
   val dataCanvasFolderMapper = new DataCanvasFolderMapper(organization)
 
   val datasetStatusManager: DatasetStatusManager =
-    new DatasetStatusManager(db, organization)
+    new DatasetStatusManagerImpl(db, organization)
 
   val packagesMapper: PackagesMapper = new PackagesMapper(organization)
 

--- a/core/src/main/scala/com/pennsieve/managers/DataUseAgreementManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DataUseAgreementManager.scala
@@ -29,11 +29,10 @@ import com.pennsieve.core.utilities.FutureEitherHelpers
 import com.pennsieve.core.utilities.FutureEitherHelpers.implicits._
 import scala.concurrent.{ ExecutionContext, Future }
 
-class DataUseAgreementManager(
-  val db: Database,
-  val organization: Organization
-) {
-  val dataUseAgreementMapper = new DataUseAgreementMapper(organization)
+trait DataUseAgreementManager {
+  def db: Database
+  def organization: Organization
+  lazy val dataUseAgreementMapper = new DataUseAgreementMapper(organization)
 
   def get(
     agreementId: Int
@@ -179,3 +178,8 @@ class DataUseAgreementManager(
         case _ => Right(())
       }
 }
+
+class DataUseAgreementManagerImpl(
+  val db: Database,
+  val organization: Organization
+) extends DataUseAgreementManager

--- a/core/src/main/scala/com/pennsieve/managers/DatasetAssetsManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetAssetsManager.scala
@@ -36,14 +36,13 @@ object DatasetAssetsManager {
   def defaultChangelogText = "initial dataset creation"
 }
 
-class DatasetAssetsManager(
-  val db: Database,
-  val datasetsMapper: DatasetsMapper
-) {
+trait DatasetAssetsManager {
+  def db: Database
+  def datasetsMapper: DatasetsMapper
 
-  val organization = datasetsMapper.organization
+  lazy val organization = datasetsMapper.organization
 
-  val datasetAssetsMapper: DatasetAssetsMapper = new DatasetAssetsMapper(
+  lazy val datasetAssetsMapper: DatasetAssetsMapper = new DatasetAssetsMapper(
     organization
   )
 
@@ -394,3 +393,8 @@ class DatasetAssetsManager(
       )
       .toEitherT
 }
+
+class DatasetAssetsManagerImpl(
+  val db: Database,
+  val datasetsMapper: DatasetsMapper
+) extends DatasetAssetsManager

--- a/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetManager.scala
@@ -94,73 +94,79 @@ object DatasetManager {
   }
 }
 
-class DatasetManager(
-  val db: Database,
-  val actor: User,
-  val datasetsMapper: DatasetsMapper
-) {
+trait DatasetManager {
+
+  def db: Database
+  def actor: User
+  def datasetsMapper: DatasetsMapper
 
   import DatasetManager._
 
-  val organization: Organization = datasetsMapper.organization
+  // All helper members are `lazy val` so a fake (or any subclass that
+  // overrides `db`/`actor`/`datasetsMapper` to throw) doesn't try to construct
+  // them at trait initialization time.
 
-  val packagesMapper: PackagesMapper = new PackagesMapper(organization)
+  lazy val organization: Organization = datasetsMapper.organization
 
-  val filesMapper: FilesMapper = new FilesMapper(organization)
+  lazy val packagesMapper: PackagesMapper = new PackagesMapper(organization)
 
-  val contributor: ContributorMapper = new ContributorMapper(organization)
+  lazy val filesMapper: FilesMapper = new FilesMapper(organization)
 
-  val contributorManager: ContributorManager =
+  lazy val contributor: ContributorMapper = new ContributorMapper(organization)
+
+  lazy val contributorManager: ContributorManager =
     new ContributorManagerImpl(db, actor, contributor, new UserManagerImpl(db))
 
-  val datasetStatusManager: DatasetStatusManager =
-    new DatasetStatusManager(db, organization)
+  lazy val datasetStatusManager: DatasetStatusManager =
+    new DatasetStatusManagerImpl(db, organization)
 
-  val datasetPublicationStatusMapper: DatasetPublicationStatusMapper =
+  lazy val datasetPublicationStatusMapper: DatasetPublicationStatusMapper =
     new DatasetPublicationStatusMapper(organization)
 
-  val datasetContributorMapper = new DatasetContributorMapper(organization)
+  lazy val datasetContributorMapper = new DatasetContributorMapper(organization)
 
-  val datasetIntegrationsMapper = new DatasetIntegrationsMapper(organization)
+  lazy val datasetIntegrationsMapper = new DatasetIntegrationsMapper(
+    organization
+  )
 
-  val webhooksMapper = new WebhooksMapper(organization)
+  lazy val webhooksMapper = new WebhooksMapper(organization)
 
-  implicit val collectionMapper: CollectionMapper =
+  implicit lazy val collectionMapper: CollectionMapper =
     new CollectionMapper(organization)
 
-  implicit val datasetTeam: DatasetTeamMapper = new DatasetTeamMapper(
+  implicit lazy val datasetTeam: DatasetTeamMapper = new DatasetTeamMapper(
     organization
   )
 
-  implicit val datasetUser: DatasetUserMapper = new DatasetUserMapper(
+  implicit lazy val datasetUser: DatasetUserMapper = new DatasetUserMapper(
     organization
   )
 
-  implicit val datasetCollection: DatasetCollectionMapper =
+  implicit lazy val datasetCollection: DatasetCollectionMapper =
     new DatasetCollectionMapper(organization)
 
-  implicit val datasetContributor: DatasetContributorMapper =
+  implicit lazy val datasetContributor: DatasetContributorMapper =
     new DatasetContributorMapper(organization)
 
-  implicit val datasetStatusLog: DatasetStatusLogMapper =
+  implicit lazy val datasetStatusLog: DatasetStatusLogMapper =
     new DatasetStatusLogMapper(organization)
 
-  val collectionManager: CollectionManager =
+  lazy val collectionManager: CollectionManager =
     new CollectionManagerImpl(db, collectionMapper)
 
-  val datasetIgnoreFiles: DatasetIgnoreFilesMapper =
+  lazy val datasetIgnoreFiles: DatasetIgnoreFilesMapper =
     new DatasetIgnoreFilesMapper(organization)
 
-  val organizationManager: OrganizationManager =
+  lazy val organizationManager: OrganizationManager =
     new OrganizationManagerImpl(db)
 
-  val datasetRegistrationMapper: DatasetRegistrationMapper =
+  lazy val datasetRegistrationMapper: DatasetRegistrationMapper =
     new DatasetRegistrationMapper(organization)
 
-  val datasetReleaseMapper: DatasetReleaseMapper =
+  lazy val datasetReleaseMapper: DatasetReleaseMapper =
     new DatasetReleaseMapper(organization)
 
-  val externalRepositoryMapper: ExternalRepositoryMapper =
+  lazy val externalRepositoryMapper: ExternalRepositoryMapper =
     new ExternalRepositoryMapper()
 
   def isLocked(
@@ -1859,3 +1865,9 @@ class DatasetManager(
         .toEitherT
     } yield repository
 }
+
+class DatasetManagerImpl(
+  val db: Database,
+  val actor: User,
+  val datasetsMapper: DatasetsMapper
+) extends DatasetManager

--- a/core/src/main/scala/com/pennsieve/managers/DatasetPreviewManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetPreviewManager.scala
@@ -32,14 +32,13 @@ import com.pennsieve.traits.PostgresProfile.api._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class DatasetPreviewManager(
-  val db: Database,
-  val datasetsMapper: DatasetsMapper
-) {
+trait DatasetPreviewManager {
+  def db: Database
+  def datasetsMapper: DatasetsMapper
 
-  val organization: Organization = datasetsMapper.organization
+  lazy val organization: Organization = datasetsMapper.organization
 
-  val previewer: DatasetPreviewerMapper = new DatasetPreviewerMapper(
+  lazy val previewer: DatasetPreviewerMapper = new DatasetPreviewerMapper(
     organization
   )
 
@@ -139,3 +138,8 @@ class DatasetPreviewManager(
     db.run(query.transactionally).toEitherT
   }
 }
+
+class DatasetPreviewManagerImpl(
+  val db: Database,
+  val datasetsMapper: DatasetsMapper
+) extends DatasetPreviewManager

--- a/core/src/main/scala/com/pennsieve/managers/DatasetPublicationStatusManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetPublicationStatusManager.scala
@@ -30,12 +30,11 @@ import slick.lifted.ColumnOrdered
 import scala.concurrent.{ ExecutionContext, Future }
 import java.time.LocalDate
 
-class DatasetPublicationStatusManager(
-  val db: Database,
-  val actor: User,
-  val datasetPublicationStatusMapper: DatasetPublicationStatusMapper,
-  val changelogEventMapper: ChangelogEventMapper
-) {
+trait DatasetPublicationStatusManager {
+  def db: Database
+  def actor: User
+  def datasetPublicationStatusMapper: DatasetPublicationStatusMapper
+  def changelogEventMapper: ChangelogEventMapper
 
   def create(
     dataset: Dataset,
@@ -99,3 +98,10 @@ class DatasetPublicationStatusManager(
   }
 
 }
+
+class DatasetPublicationStatusManagerImpl(
+  val db: Database,
+  val actor: User,
+  val datasetPublicationStatusMapper: DatasetPublicationStatusMapper,
+  val changelogEventMapper: ChangelogEventMapper
+) extends DatasetPublicationStatusManager

--- a/core/src/main/scala/com/pennsieve/managers/DatasetStatusManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/DatasetStatusManager.scala
@@ -37,12 +37,14 @@ import java.text.Normalizer
 import scala.concurrent.{ ExecutionContext, Future }
 import slick.dbio.DBIO
 
-class DatasetStatusManager(val db: Database, val organization: Organization) {
+trait DatasetStatusManager {
+  def db: Database
+  def organization: Organization
 
-  val datasetStatusMapper: DatasetStatusMapper = new DatasetStatusMapper(
+  lazy val datasetStatusMapper: DatasetStatusMapper = new DatasetStatusMapper(
     organization
   )
-  val datasetMapper: DatasetsMapper = new DatasetsMapper(organization)
+  lazy val datasetMapper: DatasetsMapper = new DatasetsMapper(organization)
 
   val datasetStatusColors: Map[String, String] = Map(
     "Grey" -> "#71747C", // No Status
@@ -340,3 +342,6 @@ class DatasetStatusManager(val db: Database, val organization: Organization) {
       )
   }
 }
+
+class DatasetStatusManagerImpl(val db: Database, val organization: Organization)
+    extends DatasetStatusManager

--- a/core/src/main/scala/com/pennsieve/managers/ExternalPublicationManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/ExternalPublicationManager.scala
@@ -25,11 +25,11 @@ import com.pennsieve.models._
 import com.pennsieve.traits.PostgresProfile.api._
 import scala.concurrent.{ ExecutionContext, Future }
 
-class ExternalPublicationManager(
-  val db: Database,
-  val organization: Organization
-) {
-  val externalPublicationMapper = new ExternalPublicationMapper(organization)
+trait ExternalPublicationManager {
+  def db: Database
+  def organization: Organization
+  lazy val externalPublicationMapper =
+    new ExternalPublicationMapper(organization)
 
   def get(
     dataset: Dataset
@@ -70,3 +70,8 @@ class ExternalPublicationManager(
         case _ => Right(())
       }
 }
+
+class ExternalPublicationManagerImpl(
+  val db: Database,
+  val organization: Organization
+) extends ExternalPublicationManager

--- a/core/src/main/scala/com/pennsieve/managers/FileManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/FileManager.scala
@@ -63,14 +63,17 @@ object FileManager {
   *  @param packageManager A package manager.
   *  @param organization The organization that the file is associated with.
   */
-class FileManager(packageManager: PackageManager, organization: Organization) {
+trait FileManager {
+  def packageManager: PackageManager
+  def organization: Organization
+
   import FileManager._
 
-  val packages: PackagesMapper = packageManager.packagesMapper
-  val files: FilesMapper = new FilesMapper(organization)
+  lazy val packages: PackagesMapper = packageManager.packagesMapper
+  lazy val files: FilesMapper = new FilesMapper(organization)
 
-  val db: Database = packageManager.db
-  val actor: User = packageManager.actor
+  lazy val db: Database = packageManager.db
+  lazy val actor: User = packageManager.actor
 
   /** Creates a new file with the given values.
     *
@@ -614,3 +617,8 @@ class FileManager(packageManager: PackageManager, organization: Organization) {
   }
 
 }
+
+class FileManagerImpl(
+  val packageManager: PackageManager,
+  val organization: Organization
+) extends FileManager

--- a/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/PackageManager.scala
@@ -64,19 +64,20 @@ import scala.collection.compat._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
-class PackageManager(datasetManager: DatasetManager) {
+trait PackageManager {
+  def datasetManager: DatasetManager
 
-  val organization: Organization = datasetManager.organization
+  lazy val organization: Organization = datasetManager.organization
 
-  val actor: User = datasetManager.actor
-  val db: Database = datasetManager.db
+  lazy val actor: User = datasetManager.actor
+  lazy val db: Database = datasetManager.db
 
-  val packagesMapper: PackagesMapper = new PackagesMapper(organization)
-  val externalFilesMapper = new ExternalFilesMapper(organization)
-  val datasetsMapper: DatasetsMapper = datasetManager.datasetsMapper
-  val filesMapper = new FilesMapper(organization)
+  lazy val packagesMapper: PackagesMapper = new PackagesMapper(organization)
+  lazy val externalFilesMapper = new ExternalFilesMapper(organization)
+  lazy val datasetsMapper: DatasetsMapper = datasetManager.datasetsMapper
+  lazy val filesMapper = new FilesMapper(organization)
 
-  val externalFileManager =
+  lazy val externalFileManager =
     new ExternalFileManager(externalFilesMapper, this)
 
   /**
@@ -771,7 +772,7 @@ class PackageManager(datasetManager: DatasetManager) {
        """
   }
 
-  implicit val packageWithFiles: GetResult[(Package, Seq[File])] =
+  implicit lazy val packageWithFiles: GetResult[(Package, Seq[File])] =
     GetResult { p =>
       val id = p.<<[Int]
       val name = p.<<[String]
@@ -906,7 +907,7 @@ class PackageManager(datasetManager: DatasetManager) {
     publishedS3VersionId: Option[String]
   )
 
-  implicit val packageHierarchy: GetResult[PackageHierarchy] =
+  implicit lazy val packageHierarchy: GetResult[PackageHierarchy] =
     GetResult { p =>
       val datasetId = p.<<[Int]
       val nodeIdPath = p.<<[Seq[String]]
@@ -1120,7 +1121,7 @@ class PackageManager(datasetManager: DatasetManager) {
 
   type PackagePath = (Package, Seq[String])
 
-  implicit val packageList: GetResult[PackagePath] =
+  implicit lazy val packageList: GetResult[PackagePath] =
     GetResult { p =>
       val datasetId = p.<<[Int]
       val parentId = p.<<[Int]
@@ -1199,3 +1200,6 @@ class PackageManager(datasetManager: DatasetManager) {
       .map(_.to(Seq))
       .toEitherT
 }
+
+class PackageManagerImpl(val datasetManager: DatasetManager)
+    extends PackageManager

--- a/core/src/main/scala/com/pennsieve/managers/WebhookManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/WebhookManager.scala
@@ -37,15 +37,14 @@ import java.time.ZonedDateTime
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.collection.compat._
 
-class WebhookManager(
-  val db: PostgresProfile.api.Database,
-  val actor: User,
-  val webhooksMapper: WebhooksMapper,
-  val webhookEventSubscriptionsMapper: WebhookEventSubscriptionsMapper,
-  val webhookEventTypesMapper: WebhookEventTypesMapper
-) {
+trait WebhookManager {
+  def db: PostgresProfile.api.Database
+  def actor: User
+  def webhooksMapper: WebhooksMapper
+  def webhookEventSubscriptionsMapper: WebhookEventSubscriptionsMapper
+  def webhookEventTypesMapper: WebhookEventTypesMapper
 
-  val organization: Organization = webhooksMapper.organization
+  lazy val organization: Organization = webhooksMapper.organization
 
   def validateWebhookValues(
     apiUrl: String,
@@ -448,3 +447,11 @@ class WebhookManager(
     } yield webhook
   }
 }
+
+class WebhookManagerImpl(
+  val db: PostgresProfile.api.Database,
+  val actor: User,
+  val webhooksMapper: WebhooksMapper,
+  val webhookEventSubscriptionsMapper: WebhookEventSubscriptionsMapper,
+  val webhookEventTypesMapper: WebhookEventTypesMapper
+) extends WebhookManager

--- a/core/src/test/scala/com/pennsieve/managers/BaseManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/BaseManagerSpec.scala
@@ -150,7 +150,13 @@ trait ManagerSpec
     user: User = superAdmin
   ): ChangelogManager = {
     val sns: SNSClient = new MockSNS
-    new ChangelogManager(database, organization, user, "test-topic", sns = sns)
+    new ChangelogManagerImpl(
+      database,
+      organization,
+      user,
+      "test-topic",
+      sns = sns
+    )
   }
 
   def datasetManager(
@@ -159,7 +165,7 @@ trait ManagerSpec
   ): DatasetManager = {
     val datasetsMapper = new DatasetsMapper(organization)
 
-    new DatasetManager(database, user, datasetsMapper)
+    new DatasetManagerImpl(database, user, datasetsMapper)
   }
 
   def datasetCollectionManager(
@@ -178,7 +184,7 @@ trait ManagerSpec
       organization
     )
 
-    new DatasetPublicationStatusManager(
+    new DatasetPublicationStatusManagerImpl(
       database,
       user,
       datasetPublicationStatusMapper,
@@ -188,7 +194,7 @@ trait ManagerSpec
 
   def datasetStatusManager(
     organization: Organization = testOrganization
-  ): DatasetStatusManager = new DatasetStatusManager(database, organization)
+  ): DatasetStatusManager = new DatasetStatusManagerImpl(database, organization)
 
   def contributorsManager(
     organization: Organization = testOrganization,
@@ -207,7 +213,7 @@ trait ManagerSpec
     organization: Organization = testOrganization,
     user: User = superAdmin
   ): FileManager =
-    new FileManager(packageManager(organization, user), organization)
+    new FileManagerImpl(packageManager(organization, user), organization)
 
   def externalFileManager(
     organization: Organization = testOrganization,
@@ -227,7 +233,7 @@ trait ManagerSpec
     organization: Organization = testOrganization,
     user: User = superAdmin
   ): PackageManager =
-    new PackageManager(datasetManager(organization, user))
+    new PackageManagerImpl(datasetManager(organization, user))
 
   def timeSeriesManager(
     organization: Organization = testOrganization
@@ -272,7 +278,7 @@ trait ManagerSpec
     val datasetIntegrationsMapper: DatasetIntegrationsMapper =
       new DatasetIntegrationsMapper(organization)
 
-    new WebhookManager(
+    new WebhookManagerImpl(
       db = database,
       actor = user,
       webhooksMapper = webhooksMapper,

--- a/etl-data-cli/src/test/scala/com/pennsieve/etl-data-cli/DataCLIDatabaseSpecHarness.scala
+++ b/etl-data-cli/src/test/scala/com/pennsieve/etl-data-cli/DataCLIDatabaseSpecHarness.scala
@@ -18,7 +18,7 @@ package com.pennsieve.etl.`data-cli`
 
 import java.util.UUID
 import com.pennsieve.db._
-import com.pennsieve.managers.DatasetStatusManager
+import com.pennsieve.managers.{ DatasetStatusManager, DatasetStatusManagerImpl }
 import com.pennsieve.models.{
   Dataset,
   File,
@@ -45,7 +45,7 @@ trait DataCLIDatabaseSpecHarness
 
   def createDataset: Dataset = {
 
-    val status = new DatasetStatusManager(dataCLIContainer.db, organization)
+    val status = new DatasetStatusManagerImpl(dataCLIContainer.db, organization)
       .create("Test")
       .await
       .toOption

--- a/jobs/src/main/scala/com/pennsieve/jobs/types/DatasetChangelogEvent.scala
+++ b/jobs/src/main/scala/com/pennsieve/jobs/types/DatasetChangelogEvent.scala
@@ -31,7 +31,7 @@ import com.pennsieve.jobs.{
   JSONParseFailException,
   JobException
 }
-import com.pennsieve.managers.ChangelogManager
+import com.pennsieve.managers.{ ChangelogManager, ChangelogManagerImpl }
 import com.pennsieve.messages.{ DatasetChangelogEventJob, EventInstance }
 import com.pennsieve.models.{
   ChangelogEventAndType,
@@ -79,7 +79,7 @@ class DatasetChangelogEvent(
     )
 
     val changelogManager =
-      new ChangelogManager(db, organization, user, eventsTopic, sns)
+      new ChangelogManagerImpl(db, organization, user, eventsTopic, sns)
     for ((eventDetail, _) <- eventDetails) {
       log.tierContext.info(s"event = ${eventDetail.eventType.asJson.noSpaces}")
     }

--- a/jobs/src/main/scala/com/pennsieve/jobs/types/DeleteJob.scala
+++ b/jobs/src/main/scala/com/pennsieve/jobs/types/DeleteJob.scala
@@ -762,7 +762,7 @@ class DeleteJob(
       datasetTable = new DatasetsMapper(organization)
       assetTable = new DatasetAssetsMapper(organization)
 
-      datasetAssetsManager = new DatasetAssetsManager(
+      datasetAssetsManager = new DatasetAssetsManagerImpl(
         container.db,
         datasetTable
       )

--- a/jobs/src/test/scala/com/pennsieve/jobs/types/DeleteJobSpec.scala
+++ b/jobs/src/test/scala/com/pennsieve/jobs/types/DeleteJobSpec.scala
@@ -40,7 +40,11 @@ import com.pennsieve.db.{
 import com.pennsieve.domain.{ CoreError, ThrowableError }
 import com.pennsieve.jobs._
 import com.pennsieve.jobs.types.DeleteJob.Container
-import com.pennsieve.managers.{ DatasetAssetsManager, ManagerSpec }
+import com.pennsieve.managers.{
+  DatasetAssetsManager,
+  DatasetAssetsManagerImpl,
+  ManagerSpec
+}
 import com.pennsieve.messages._
 import com.pennsieve.models.FileType.Aperio
 import com.pennsieve.models.PackageType.{ ExternalFile, Slide, TimeSeries }
@@ -564,7 +568,7 @@ class DeleteJobSpec
     val content = "#Markdown content\nA paragraph!"
 
     lazy val datasetAssetsManager: DatasetAssetsManager =
-      new DatasetAssetsManager(database, datasetTable)
+      new DatasetAssetsManagerImpl(database, datasetTable)
 
     val readmeAsset = datasetAssetsManager
       .createOrUpdateReadme(


### PR DESCRIPTION
## Changes Proposed
Follow up to https://github.com/Pennsieve/pennsieve-api/pull/379.

Add trait layer for the remaining managers before tackling the `DatasetsController`.

## Checklist
- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.