### PR TITLE
Add viewerAssetID to call to createChannel

### DIFF
--- a/api/src/main/scala/com/pennsieve/api/TimeSeriesController.scala
+++ b/api/src/main/scala/com/pennsieve/api/TimeSeriesController.scala
@@ -59,6 +59,7 @@ import org.scalatra.swagger.Swagger
 import org.scalatra.swagger.SwaggerSupportSyntax.OperationBuilder
 import io.circe.generic.auto._
 
+import java.util.UUID
 import scala.collection.SortedSet
 import scala.concurrent.{ ExecutionContext, Future }
 import scalikejdbc.{ AutoSession, DBSession }
@@ -86,7 +87,8 @@ case class TimeSeriesChannelWriteRequest(
   group: Option[String],
   spikeDuration: Option[Long],
   properties: List[ModelPropertyRO],
-  id: Option[String] = None
+  id: Option[String] = None,
+  viewerAssetId: Option[UUID] = None
 )
 
 case class AnnotationResults(
@@ -309,7 +311,8 @@ class TimeSeriesController(
                 c.group,
                 c.lastAnnotation,
                 c.spikeDuration,
-                properties
+                properties,
+                c.viewerAssetId
               )
               .orError()
           } yield channel

--- a/api/src/test/scala/com/pennsieve/api/TestTimeSeriesController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestTimeSeriesController.scala
@@ -20,6 +20,7 @@ import com.pennsieve.db.TimeSeriesAnnotation
 import com.pennsieve.models.{ Channel, ModelProperty, Package }
 import com.pennsieve.dtos.{ ChannelDTO, ModelPropertiesDTO, ModelPropertyRO }
 
+import java.util.UUID
 import scala.collection.SortedSet
 import com.pennsieve.helpers.{ DataSetTestMixin, TimeSeriesHelper }
 import com.pennsieve.models.PackageState.READY
@@ -275,6 +276,42 @@ class TestTimeSeriesController
     ) {
       status should equal(201)
       parsedBody.extract[List[ChannelDTO]] should have size 5
+    }
+  }
+
+  it should "create channel with viewer_asset_id" in {
+    val tsPkg = createTimeSeriesPackage()._1
+    val assetId = UUID.randomUUID()
+
+    val request = TimeSeriesChannelWriteRequest(
+      name = "asset-linked",
+      start = 1000,
+      end = 10000,
+      unit = "unit",
+      rate = 256.5,
+      channelType = "eeg",
+      lastAnnotation = 0,
+      group = None,
+      spikeDuration = None,
+      properties = List(),
+      viewerAssetId = Some(assetId)
+    )
+    val json = write(request)
+
+    postJson(
+      s"/${tsPkg.nodeId}/channels",
+      json,
+      headers = authorizationHeader(loggedInJwt)
+    ) {
+      status should equal(201)
+      val created = parsedBody.extract[ChannelDTO]
+      created.content.name should equal(request.name)
+
+      val persisted = timeSeriesManager
+        .getChannel(created.content.id, tsPkg)
+        .await
+        .value
+      persisted.viewerAssetId shouldBe Some(assetId)
     }
   }
 

--- a/api/src/test/scala/com/pennsieve/api/TestTimeSeriesController.scala
+++ b/api/src/test/scala/com/pennsieve/api/TestTimeSeriesController.scala
@@ -308,7 +308,7 @@ class TestTimeSeriesController
       created.content.name should equal(request.name)
 
       val persisted = timeSeriesManager
-        .getChannel(created.content.id, tsPkg)
+        .getChannelByNodeId(created.content.id, tsPkg)
         .await
         .value
       persisted.viewerAssetId shouldBe Some(assetId)

--- a/core/src/main/scala/com/pennsieve/managers/TimeSeriesManager.scala
+++ b/core/src/main/scala/com/pennsieve/managers/TimeSeriesManager.scala
@@ -51,24 +51,26 @@ class TimeSeriesManager(db: Database, organization: Organization) {
     group: Option[String],
     lastAnnotation: Long,
     spikeDuration: Option[Long] = None,
-    properties: List[ModelProperty] = Nil
+    properties: List[ModelProperty] = Nil,
+    viewerAssetId: Option[UUID] = None
   )(implicit
     ec: ExecutionContext
   ): EitherT[Future, CoreError, Channel] = {
     val nodeId = NodeCodes.generateId(NodeCodes.channelCode)
     val query = table returning table += Channel(
-      nodeId,
-      `package`.id,
-      name.trim,
-      start,
-      end,
-      unit,
-      rate,
-      `type`,
-      group,
-      lastAnnotation,
-      spikeDuration,
-      properties
+      nodeId = nodeId,
+      packageId = `package`.id,
+      name = name.trim,
+      start = start,
+      end = end,
+      unit = unit,
+      rate = rate,
+      `type` = `type`,
+      group = group,
+      lastAnnotation = lastAnnotation,
+      spikeDuration = spikeDuration,
+      properties = properties,
+      viewerAssetId = viewerAssetId
     )
     db.run(query.transactionally).toEitherT
   }

--- a/core/src/test/scala/com/pennsieve/managers/TimeSeriesManagerSpec.scala
+++ b/core/src/test/scala/com/pennsieve/managers/TimeSeriesManagerSpec.scala
@@ -249,6 +249,53 @@ class TimeSeriesManagerSpec extends BaseManagerSpec {
     tm.getChannelsByViewerAssetId(UUID.randomUUID()).await.value shouldBe empty
   }
 
+  "creating a channel with viewer_asset_id" should "persist it on the new row" in {
+    val user = createUser()
+    val tm = timeSeriesManager()
+
+    val dataset = createDataset(user = user)
+    val p = createPackage(
+      user = user,
+      dataset = dataset,
+      `type` = PackageType.TimeSeries
+    )
+
+    val assetId = UUID.randomUUID()
+    val channel = tm
+      .createChannel(
+        p,
+        "linked",
+        0,
+        10,
+        "ms",
+        1.0,
+        "eeg",
+        None,
+        0,
+        viewerAssetId = Some(assetId)
+      )
+      .await
+      .value
+
+    channel.viewerAssetId shouldBe Some(assetId)
+    tm.getChannel(channel.id, p).await.value.viewerAssetId shouldBe Some(assetId)
+  }
+
+  "creating a channel without viewer_asset_id" should "leave it null" in {
+    val user = createUser()
+    val tm = timeSeriesManager()
+
+    val dataset = createDataset(user = user)
+    val p = createPackage(
+      user = user,
+      dataset = dataset,
+      `type` = PackageType.TimeSeries
+    )
+
+    val channel = createChannel(p, "unlinked")(tm)
+    channel.viewerAssetId shouldBe None
+  }
+
   "a channel on a timeseries package created by a user" should "readable by another user in the same group" in {
     val user = createUser()
     val tm = timeSeriesManager()


### PR DESCRIPTION
Optional viewerAssetID when creating a channel. Updates to TimeseriesController and TimeseriesManager

Also tests


## Checklist

- [x] unit tests added and/or verified that tests pass
- [x] I have considered any possible security implications of this change
- [x] I have considered deployment issues.
